### PR TITLE
fixed validator package name

### DIFF
--- a/middleware/parameter.go
+++ b/middleware/parameter.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
 	"github.com/go-openapi/swag"
-	validate "github.com/go-openapi/validate/validation"
+	validate "github.com/go-openapi/validate"
 )
 
 const defaultMaxMemory = 32 << 20


### PR DESCRIPTION
Please merge this fix, my existing swagger API build fails.

Cheers 👍

github.com/go-openapi/runtime/middleware/parameter.go:31:2: cannot find package "github.com/go-openapi/validate/validation" in any of:
        /usr/local/Cellar/go/1.6.1/libexec/src/github.com/go-openapi/validate/validation (from $GOROOT)
        /Users/me/gocode/src/github.com/go-openapi/validate/validation (from $GOPATH)