### PR TITLE
Add missing Content-Type header for form data

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -143,10 +143,12 @@ func (r *request) BuildHTTP(mediaType string, producers map[string]runtime.Produ
 
 			}()
 			return req, nil
+		} else {
+			req.Header.Set(runtime.HeaderContentType, mediaType)
+			// write the form values as the body
+			buf.WriteString(r.formFields.Encode())
+			return req, nil
 		}
-		// write the form values as the body
-		buf.WriteString(r.formFields.Encode())
-		return req, nil
 	}
 
 	// if there is payload, use the producer to write the payload, and then


### PR DESCRIPTION
Without this change, requests with non-multipart form data do not have a Content-Type header set. This can cause the request to fail.