### PR TITLE
Fix precedence of default producer

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -379,12 +379,14 @@ func (c *Context) NotFound(rw http.ResponseWriter, r *http.Request) {
 
 // Respond renders the response after doing some content negotiation
 func (c *Context) Respond(rw http.ResponseWriter, r *http.Request, produces []string, route *MatchedRoute, data interface{}) {
-	offers := []string{c.api.DefaultProduces()}
+	offers := []string{}
 	for _, mt := range produces {
 		if mt != c.api.DefaultProduces() {
 			offers = append(offers, mt)
 		}
 	}
+	// the default producer is last so more specific producers take precedence
+	offers = append(offers, c.api.DefaultProduces())
 
 	format := c.ResponseFormat(r, offers)
 	rw.Header().Set(runtime.HeaderContentType, format)


### PR DESCRIPTION
The default producer should be last in the list of producers, rather than first. Otherwise, it can take precedence over the intended producers for a response.