### PR TITLE
Add "application/octet-stream" to consumers and producers

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -64,14 +64,16 @@ func New(host, basePath string, schemes []string) *Runtime {
 
 	// TODO: actually infer this stuff from the spec
 	rt.Consumers = map[string]runtime.Consumer{
-		runtime.JSONMime: runtime.JSONConsumer(),
-		runtime.XMLMime:  runtime.XMLConsumer(),
-		runtime.TextMime: runtime.TextConsumer(),
+		runtime.JSONMime:    runtime.JSONConsumer(),
+		runtime.XMLMime:     runtime.XMLConsumer(),
+		runtime.TextMime:    runtime.TextConsumer(),
+		runtime.DefaultMime: runtime.ByteStreamConsumer(),
 	}
 	rt.Producers = map[string]runtime.Producer{
-		runtime.JSONMime: runtime.JSONProducer(),
-		runtime.XMLMime:  runtime.XMLProducer(),
-		runtime.TextMime: runtime.TextProducer(),
+		runtime.JSONMime:    runtime.JSONProducer(),
+		runtime.XMLMime:     runtime.XMLProducer(),
+		runtime.TextMime:    runtime.TextProducer(),
+		runtime.DefaultMime: runtime.ByteStreamProducer(),
 	}
 	rt.Transport = http.DefaultTransport
 	rt.Jar = nil

--- a/internal/testing/simplepetstore/api.go
+++ b/internal/testing/simplepetstore/api.go
@@ -294,10 +294,10 @@ var swaggerJSON = `{
   },
   "definitions": {
     "pet": {
-      "required": [
-        "id",
-        "name"
-      ],
+			"required": [
+				"name",
+				"status"
+			],
       "properties": {
         "id": {
           "type": "integer",
@@ -306,20 +306,23 @@ var swaggerJSON = `{
         "name": {
           "type": "string"
         },
-        "tag": {
+        "status": {
           "type": "string"
-        }
+        },
+				"tags": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					}
+				}
       }
     },
     "petInput": {
       "allOf": [
         {
-          "$ref": "pet"
+          "$ref": "#/definitions/pet"
         },
         {
-          "required": [
-            "name"
-          ],
           "properties": {
             "id": {
               "type": "integer",

--- a/middleware/untyped/api_test.go
+++ b/middleware/untyped/api_test.go
@@ -117,7 +117,6 @@ func TestUntypedAppValidation(t *testing.T) {
         "security": [
           {"basic":[]}
         ],
-        "operationId": "someOperation",
         "parameters": [
           {
             "name": "skip",
@@ -162,7 +161,6 @@ func TestUntypedAppValidation(t *testing.T) {
 	        "security": [
 	          {"basic":[]}
 	        ],
-	  			"operationId": "someOperation",
 	  			"parameters": [
 	  				{
 				  		"name": "skip",


### PR DESCRIPTION
Runtime was missing the content type `application/octet-stream` for the consumers and producers, generating the error `no consumer: "application/octet-stream"` on the client generated by the go-swagger.