### PR TITLE
replace request's os.File with NamedReadCloser

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -62,7 +62,7 @@ type request struct {
 	header     http.Header
 	query      url.Values
 	formFields url.Values
-	fileFields map[string]*os.File
+	fileFields map[string]runtime.NamedReadCloser
 	payload    interface{}
 	timeout    time.Duration
 }
@@ -236,17 +236,19 @@ func (r *request) SetPathParam(name string, value string) error {
 }
 
 // SetFileParam adds a file param to the request
-func (r *request) SetFileParam(name string, file *os.File) error {
-	fi, err := os.Stat(file.Name())
-	if err != nil {
-		return err
-	}
-	if fi.IsDir() {
-		return fmt.Errorf("%q is a directory, only files are supported", file.Name())
+func (r *request) SetFileParam(name string, file runtime.NamedReadCloser) error {
+	if actualFile, ok := file.(*os.File); ok {
+		fi, err := os.Stat(actualFile.Name())
+		if err != nil {
+			return err
+		}
+		if fi.IsDir() {
+			return fmt.Errorf("%q is a directory, only files are supported", file.Name())
+		}
 	}
 
 	if r.fileFields == nil {
-		r.fileFields = make(map[string]*os.File)
+		r.fileFields = make(map[string]runtime.NamedReadCloser)
 	}
 	if r.formFields == nil {
 		r.formFields = make(url.Values)

--- a/client_request.go
+++ b/client_request.go
@@ -15,7 +15,7 @@
 package runtime
 
 import (
-	"os"
+	"io"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -45,9 +45,15 @@ type ClientRequest interface {
 
 	SetPathParam(string, string) error
 
-	SetFileParam(string, *os.File) error
+	SetFileParam(string, NamedReadCloser) error
 
 	SetBodyParam(interface{}) error
 
 	SetTimeout(time.Duration) error
+}
+
+// NamedReadCloser represents a named ReadCloser interface
+type NamedReadCloser interface {
+	io.ReadCloser
+	Name() string
 }

--- a/client_request_test.go
+++ b/client_request_test.go
@@ -16,7 +16,6 @@ package runtime
 
 import (
 	"net/http"
-	"os"
 	"testing"
 	"time"
 
@@ -43,7 +42,7 @@ func (t *trw) SetFormParam(_ string, _ ...string) error { return nil }
 
 func (t *trw) SetPathParam(_ string, _ string) error { return nil }
 
-func (t *trw) SetFileParam(_ string, _ *os.File) error { return nil }
+func (t *trw) SetFileParam(_ string, _ NamedReadCloser) error { return nil }
 
 func (t *trw) SetBodyParam(body interface{}) error {
 	t.Body = body


### PR DESCRIPTION
Tested the changes in this PR successfully against:

- [go-openapi/runtime (master)](https://github.com/go-openapi/runtime)
- [go-swagger/go-swagger (master)](https://github.com/go-swagger/go-swagger)

This PR fixes issue #7 