### PR TITLE
simplify testProducer result code of last PR

### DIFF
--- a/bytestream_test.go
+++ b/bytestream_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"bytes"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -9,22 +10,105 @@ import (
 
 func TestByteStreamConsumer(t *testing.T) {
 	cons := ByteStreamConsumer()
-	expected := "the data for the stream to be sent over the wire"
-	rdr := bytes.NewBufferString(expected)
-	var in bytes.Buffer
 
-	if assert.NoError(t, cons.Consume(rdr, &in)) {
-		assert.Equal(t, expected, in.String())
+	expected := "the data for the stream to be sent over the wire"
+
+	// can consume as a Writer
+	var b bytes.Buffer
+	if assert.NoError(t, cons.Consume(bytes.NewBufferString(expected), &b)) {
+		assert.Equal(t, expected, b.String())
 	}
+
+	// can consume as an UnmarshalBinary
+	var bu binaryUnmarshalDummy
+	if assert.NoError(t, cons.Consume(bytes.NewBufferString(expected), &bu)) {
+		assert.Equal(t, expected, bu.str)
+	}
+
+	// can consume as a binary slice
+	var bs []byte
+	if assert.NoError(t, cons.Consume(bytes.NewBufferString(expected), &bs)) {
+		assert.Equal(t, expected, string(bs))
+	}
+	type binarySlice []byte
+	var bs2 binarySlice
+	if assert.NoError(t, cons.Consume(bytes.NewBufferString(expected), &bs2)) {
+		assert.Equal(t, expected, string(bs2))
+	}
+
+	// passing in a nilslice wil result in an error
+	var ns *[]byte
+	assert.Error(t, cons.Consume(bytes.NewBufferString(expected), &ns))
+
+	// passing in nil wil result in an error as well
+	assert.Error(t, cons.Consume(bytes.NewBufferString(expected), nil))
+
+	// a reader who results in an error, will make it fail
+	assert.Error(t, cons.Consume(new(nopReader), &bu))
+	assert.Error(t, cons.Consume(new(nopReader), &bs))
+
+	// the readers can also not be nil
+	assert.Error(t, cons.Consume(nil, &bs))
+}
+
+type binaryUnmarshalDummy struct {
+	str string
+}
+
+func (b *binaryUnmarshalDummy) UnmarshalBinary(bytes []byte) error {
+	if len(bytes) == 0 {
+		return errors.New("no text given")
+	}
+
+	b.str = string(bytes)
+	return nil
 }
 
 func TestByteStreamProducer(t *testing.T) {
 	cons := ByteStreamProducer()
-	var wrtr bytes.Buffer
 	expected := "the data for the stream to be sent over the wire"
-	out := bytes.NewBufferString(expected)
 
-	if assert.NoError(t, cons.Produce(&wrtr, out)) {
-		assert.Equal(t, expected, wrtr.String())
+	var rdr bytes.Buffer
+
+	// can produce using a reader
+	if assert.NoError(t, cons.Produce(&rdr, bytes.NewBufferString(expected))) {
+		assert.Equal(t, expected, rdr.String())
+		rdr.Reset()
 	}
+
+	// can produce using a binary marshaller
+	if assert.NoError(t, cons.Produce(&rdr, &binaryMarshalDummy{expected})) {
+		assert.Equal(t, expected, rdr.String())
+		rdr.Reset()
+	}
+
+	// binary slices can also be used to produce
+	if assert.NoError(t, cons.Produce(&rdr, []byte(expected))) {
+		assert.Equal(t, expected, rdr.String())
+		rdr.Reset()
+	}
+	type binarySlice []byte
+	if assert.NoError(t, cons.Produce(&rdr, binarySlice(expected))) {
+		assert.Equal(t, expected, rdr.String())
+		rdr.Reset()
+	}
+
+	// when binaryMarshal data is used, its potential error gets propagated
+	assert.Error(t, cons.Produce(&rdr, new(binaryMarshalDummy)))
+	// nil data should never be accepted either
+	assert.Error(t, cons.Produce(&rdr, nil))
+	// nil readers should also never be acccepted
+	assert.Error(t, cons.Produce(nil, bytes.NewBufferString(expected)))
+}
+
+type binaryMarshalDummy struct {
+	str string
+}
+
+func (b *binaryMarshalDummy) MarshalBinary() ([]byte, error) {
+	if len(b.str) == 0 {
+		return nil, errors.New("no text set")
+	}
+
+	return []byte(b.str), nil
 }

--- a/text.go
+++ b/text.go
@@ -21,8 +21,6 @@ import (
 	"io"
 	"reflect"
 	"unsafe"
-
-	"github.com/go-openapi/swag"
 )
 
 // TextConsumer creates a new text consumer
@@ -42,29 +40,21 @@ func TextConsumer() Consumer {
 // TextProducer creates a new text producer
 func TextProducer() Producer {
 	return ProducerFunc(func(writer io.Writer, data interface{}) error {
-		var buf *bytes.Buffer
-		switch tped := data.(type) {
-		case *string:
-			buf = bytes.NewBufferString(swag.StringValue(tped))
-		case string:
-			buf = bytes.NewBufferString(tped)
-		default:
-			if data == nil {
-				return errors.New("no data given to produce text from")
-			}
-
-			t, v := reflect.TypeOf(data), reflect.ValueOf(data)
-			if t.Kind() == reflect.Ptr {
-				v = v.Elem()
-				t = t.Elem()
-			}
-
-			if t.Kind() != reflect.String {
-				return fmt.Errorf("%T is not supported by the TextProducer", data)
-			}
-
-			buf = bytes.NewBufferString(v.String())
+		if data == nil {
+			return errors.New("no data given to produce text from")
 		}
+
+		t, v := reflect.TypeOf(data), reflect.ValueOf(data)
+		if t.Kind() == reflect.Ptr {
+			v = v.Elem()
+			t = t.Elem()
+		}
+
+		if t.Kind() != reflect.String {
+			return fmt.Errorf("%T is not a supported type by the TextProducer", data)
+		}
+
+		buf := bytes.NewBufferString(v.String())
 		_, err := buf.WriteTo(writer)
 		return err
 	})

--- a/text.go
+++ b/text.go
@@ -26,6 +26,10 @@ import (
 // TextConsumer creates a new text consumer
 func TextConsumer() Consumer {
 	return ConsumerFunc(func(reader io.Reader, data interface{}) error {
+		if reader == nil {
+			return errors.New("TextConsumer requires a reader") // early exit
+		}
+
 		buf := new(bytes.Buffer)
 		_, err := buf.ReadFrom(reader)
 		if err != nil {
@@ -59,6 +63,10 @@ func TextConsumer() Consumer {
 // TextProducer creates a new text producer
 func TextProducer() Producer {
 	return ProducerFunc(func(writer io.Writer, data interface{}) error {
+		if writer == nil {
+			return errors.New("TextProducer requires a writer") // early exit
+		}
+
 		if data == nil {
 			return errors.New("no data given to produce text from")
 		}

--- a/text_test.go
+++ b/text_test.go
@@ -47,6 +47,9 @@ func TestTextConsumer(t *testing.T) {
 	// when readers can't be read, those errors will be propogated as well
 	assert.Error(t, cons.Consume(new(nopReader), &tu))
 
+	// readers can also not be nil
+	assert.Error(t, cons.Consume(nil, &tu))
+
 	// can't consume nil ptr's or unsupported types
 	assert.Error(t, cons.Consume(bytes.NewBuffer([]byte(consProdText)), nil))
 	assert.Error(t, cons.Consume(bytes.NewBuffer([]byte(consProdText)), 42))
@@ -118,6 +121,9 @@ func TestTextProducer(t *testing.T) {
 	rw8 := httptest.NewRecorder()
 	err8 := prod.Produce(rw8, nil)
 	assert.Error(t, err8)
+
+	// writer can not be nil
+	assert.Error(t, prod.Produce(nil, &textMarshalDummy{answer}))
 
 	// should not work for a textMarshaler that returns an error during marshalling
 	rw9 := httptest.NewRecorder()

--- a/text_test.go
+++ b/text_test.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"bytes"
+	"errors"
 	"net/http/httptest"
 	"testing"
 
@@ -26,10 +27,49 @@ var consProdText = `The quick brown fox jumped over the lazy dog.`
 
 func TestTextConsumer(t *testing.T) {
 	cons := TextConsumer()
-	var data string
-	err := cons.Consume(bytes.NewBuffer([]byte(consProdText)), &data)
-	assert.NoError(t, err)
-	assert.Equal(t, consProdText, data)
+
+	// can consume as a string
+	var str string
+	err1 := cons.Consume(bytes.NewBuffer([]byte(consProdText)), &str)
+	assert.NoError(t, err1)
+	assert.Equal(t, consProdText, str)
+
+	var tu textUnmarshalDummy
+
+	// can consume as a TextUnmarshaler
+	err3 := cons.Consume(bytes.NewBuffer([]byte(consProdText)), &tu)
+	assert.NoError(t, err3)
+	assert.Equal(t, consProdText, tu.str)
+
+	// text unmarshal objects can return an error as well, this will be propagated
+	assert.Error(t, cons.Consume(bytes.NewBuffer(nil), &tu))
+
+	// when readers can't be read, those errors will be propogated as well
+	assert.Error(t, cons.Consume(new(nopReader), &tu))
+
+	// can't consume nil ptr's or unsupported types
+	assert.Error(t, cons.Consume(bytes.NewBuffer([]byte(consProdText)), nil))
+	assert.Error(t, cons.Consume(bytes.NewBuffer([]byte(consProdText)), 42))
+	assert.Error(t, cons.Consume(bytes.NewBuffer([]byte(consProdText)), &struct{}{}))
+}
+
+type textUnmarshalDummy struct {
+	str string
+}
+
+func (t *textUnmarshalDummy) UnmarshalText(b []byte) error {
+	if len(b) == 0 {
+		return errors.New("no text given")
+	}
+
+	t.str = string(b)
+	return nil
+}
+
+type nopReader struct{}
+
+func (n *nopReader) Read(p []byte) (int, error) {
+	return 0, errors.New("nop")
 }
 
 func TestTextProducer(t *testing.T) {
@@ -56,12 +96,50 @@ func TestTextProducer(t *testing.T) {
 	assert.NoError(t, err4)
 	assert.Equal(t, consProdText, rw4.Body.String())
 
-	// should not work with anything that's not (indirectly) a string
+	const answer = "42"
+
+	// Should always work with objects implementing Stringer interface
 	rw5 := httptest.NewRecorder()
-	err5 := prod.Produce(rw5, 42)
-	assert.Error(t, err5)
-	// nil values should also be safely caught with an error
+	err5 := prod.Produce(rw5, &stringerDummy{answer})
+	assert.NoError(t, err5)
+	assert.Equal(t, answer, rw5.Body.String())
+
+	// Should always work with objects implementing TextMarshaler interface
 	rw6 := httptest.NewRecorder()
-	err6 := prod.Produce(rw6, nil)
-	assert.Error(t, err6)
+	err6 := prod.Produce(rw6, &textMarshalDummy{answer})
+	assert.NoError(t, err6)
+	assert.Equal(t, answer, rw6.Body.String())
+
+	// should not work with anything that's not (indirectly) a string
+	rw7 := httptest.NewRecorder()
+	err7 := prod.Produce(rw7, 42)
+	assert.Error(t, err7)
+	// nil values should also be safely caught with an error
+	rw8 := httptest.NewRecorder()
+	err8 := prod.Produce(rw8, nil)
+	assert.Error(t, err8)
+
+	// should not work for a textMarshaler that returns an error during marshalling
+	rw9 := httptest.NewRecorder()
+	err9 := prod.Produce(rw9, new(textMarshalDummy))
+	assert.Error(t, err9)
+}
+
+type stringerDummy struct {
+	str string
+}
+
+func (t *stringerDummy) String() string {
+	return t.str
+}
+
+type textMarshalDummy struct {
+	str string
+}
+
+func (t *textMarshalDummy) MarshalText() ([]byte, error) {
+	if t.str == "" {
+		return nil, errors.New("no text set")
+	}
+	return []byte(t.str), nil
 }


### PR DESCRIPTION
Simplifies code that was the result of PR #29, thinking back at the code on one of my walks, made me realize that the body of the default case, actually also applies equally well to a normal `string`/`*string`, so there is no reason to make this an exception, and thus needlessly making things not only more complex, but also more expensive (even though a cost that is probably neglectable).