### PR TITLE
Check for non-empty ConsumesMediaTypes string

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -230,8 +230,12 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 
 	// TODO: pick appropriate media type
 	cmt := r.DefaultMediaType
-	if len(operation.ConsumesMediaTypes) > 0 {
-		cmt = operation.ConsumesMediaTypes[0]
+	for _, mediaType := range operation.ConsumesMediaTypes {
+		// Pick first non-empty media type
+		if mediaType != "" {
+			cmt = mediaType
+			break
+		}
 	}
 
 	req, err := request.BuildHTTP(cmt, r.Producers, r.Formats)


### PR DESCRIPTION
Fall back to default media type if ClientOperation contains an empty
string as the ConsumesMediaTypes. This supports code generators such
as go-swagger which generate code like this:

	ConsumesMediaTypes: []string{""},

... if the swagger spec does not contain a "consumes" element.