### PR TITLE
Set BasePath and PathPattern on routeEntry

### DIFF
--- a/middleware/router.go
+++ b/middleware/router.go
@@ -232,6 +232,8 @@ func (d *defaultRouteBuilder) AddRoute(method, path string, operation *spec.Oper
 		}
 
 		record := denco.NewRecord(pathConverter.ReplaceAllString(path, ":$1"), &routeEntry{
+			BasePath:       bp,
+			PathPattern:    path,
 			Operation:      operation,
 			Handler:        handler,
 			Consumes:       consumes,


### PR DESCRIPTION
The BasePath and PathPattern routeEntry fields were previously unset.

Set them when adding a route; these values can be useful when retrieved
from the context for adding to telemetry.

Signed-off-by: James Bowes <jbowes@repl.ca>