### PR TITLE
Make File implement io.Reader

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,27 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runtime
+
+import "mime/multipart"
+
+// File represents an uploaded file.
+type File struct {
+	Data   multipart.File
+	Header *multipart.FileHeader
+}
+
+func (f File) Read(p []byte) (n int, err error) {
+	return f.Data.Read(p)
+}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,14 @@
+package runtime
+
+import (
+	"github.com/stretchr/testify/assert"
+	"io"
+	"testing"
+)
+
+func TestFileImplementsIOReader(t *testing.T) {
+	var file interface{} = File{}
+	expected := "that File implements io.Reader"
+	_, ok := file.(io.Reader)
+	assert.True(t, ok, expected)
+}

--- a/interfaces.go
+++ b/interfaces.go
@@ -15,17 +15,9 @@
 package runtime
 
 import (
-	"io"
-	"mime/multipart"
-
 	"github.com/go-openapi/strfmt"
+	"io"
 )
-
-// File represents an uploaded file.
-type File struct {
-	Data   multipart.File
-	Header *multipart.FileHeader
-}
 
 // OperationHandlerFunc an adapter for a function to the OperationHandler interface
 type OperationHandlerFunc func(interface{}) (interface{}, error)


### PR DESCRIPTION
When go-swagger generated an api with an endpoint that returned a `file` with the content-type of `application/octet-stream` the endpoint would panic. The `application/octet-stream `maps to `ByteStream{Producer|Consumer}` and the `ByteStreamProducer` can only serialize implementations of `io.Reader`. 

This Fixes #42, and adds a simple test that asserts that `File` implements io.Reader.