### PR TITLE
Swap gorilla/context by standard context - Closes #47

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,6 @@ install:
 - go get -u github.com/stretchr/testify/assert
 - go get -u golang.org/x/net/context
 - go get -u gopkg.in/yaml.v2
-- go get -u github.com/gorilla/context
 - go get -u github.com/go-openapi/analysis
 - go get -u github.com/go-openapi/errors
 - go get -u github.com/go-openapi/loads

--- a/middleware/body_test.go
+++ b/middleware/body_test.go
@@ -38,9 +38,9 @@ func TestBindRequest_BodyValidation(t *testing.T) {
 	if assert.NoError(t, err) {
 		req.Header.Set("Content-Type", runtime.JSONMime)
 
-		ri, ok := ctx.RouteInfo(req)
+		ri, rCtx, ok := ctx.RouteInfo(req)
 		if assert.True(t, ok) {
-
+			req = rCtx
 			err := ctx.BindValidRequest(req, ri, rbn(func(r *http.Request, rr *MatchedRoute) error {
 				defer r.Body.Close()
 				var data interface{}
@@ -65,9 +65,9 @@ func TestBindRequest_DeleteNoBody(t *testing.T) {
 	if assert.NoError(t, err) {
 		req.Header.Set("Accept", "*/*")
 
-		ri, ok := ctx.RouteInfo(req)
+		ri, rCtx, ok := ctx.RouteInfo(req)
 		if assert.True(t, ok) {
-
+			req = rCtx
 			err := ctx.BindValidRequest(req, ri, rbn(func(r *http.Request, rr *MatchedRoute) error {
 				return nil
 			}))
@@ -83,9 +83,9 @@ func TestBindRequest_DeleteNoBody(t *testing.T) {
 		req.Header.Set("Content-Type", runtime.JSONMime)
 		req.ContentLength = 1
 
-		ri, ok := ctx.RouteInfo(req)
+		ri, rCtx, ok := ctx.RouteInfo(req)
 		if assert.True(t, ok) {
-
+			req = rCtx
 			err := ctx.BindValidRequest(req, ri, rbn(func(r *http.Request, rr *MatchedRoute) error {
 				defer r.Body.Close()
 				var data interface{}

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -68,7 +68,8 @@ func (fn ResponderFunc) WriteResponse(rw http.ResponseWriter, pr runtime.Produce
 }
 
 // Context is a type safe wrapper around an untyped request context
-// used throughout to store request context with the gorilla context module
+// used throughout to store request context with the standard context attached
+// to the http.Request
 type Context struct {
 	spec     *loads.Document
 	analyzer *analysis.Spec

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -15,6 +15,7 @@
 package middleware
 
 import (
+	stdContext "context"
 	"log"
 	"net/http"
 	"os"
@@ -29,7 +30,6 @@ import (
 	"github.com/go-openapi/runtime/security"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
-	"github.com/gorilla/context"
 )
 
 // Debug when true turns on verbose logging
@@ -106,10 +106,15 @@ func newRoutableUntypedAPI(spec *loads.Document, api *untyped.API, context *Cont
 
 				var handler http.Handler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 					// lookup route info in the context
-					route, _ := context.RouteInfo(r)
+					route, rCtx, _ := context.RouteInfo(r)
+					if rCtx != nil {
+						r = rCtx
+					}
 
 					// bind and validate the request using reflection
-					bound, validation := context.BindAndValidate(r, route)
+					var bound interface{}
+					var validation error
+					bound, r, validation = context.BindAndValidate(r, route)
 					if validation != nil {
 						context.Respond(w, r, route.Produces, route, validation)
 						return
@@ -292,19 +297,23 @@ func (c *Context) BindValidRequest(request *http.Request, route *MatchedRoute, b
 }
 
 // ContentType gets the parsed value of a content type
-func (c *Context) ContentType(request *http.Request) (string, string, error) {
-	if v, ok := context.GetOk(request, ctxContentType); ok {
-		if val, ok := v.(*contentTypeValue); ok {
-			return val.MediaType, val.Charset, nil
-		}
+// Returns the media type, its charset and a shallow copy of the request
+// when its context doesn't contain the content type value, otherwise it returns
+// the same request
+// Returns the error that runtime.ContentType may retunrs.
+func (c *Context) ContentType(request *http.Request) (string, string, *http.Request, error) {
+	var rCtx = request.Context()
+
+	if v, ok := rCtx.Value(ctxContentType).(*contentTypeValue); ok {
+		return v.MediaType, v.Charset, request, nil
 	}
 
 	mt, cs, err := runtime.ContentType(request.Header)
 	if err != nil {
-		return "", "", err
+		return "", "", nil, err
 	}
-	context.Set(request, ctxContentType, &contentTypeValue{mt, cs})
-	return mt, cs, nil
+	rCtx = stdContext.WithValue(rCtx, ctxContentType, &contentTypeValue{mt, cs})
+	return mt, cs, request.WithContext(rCtx), nil
 }
 
 // LookupRoute looks a route up and returns true when it is found
@@ -316,34 +325,40 @@ func (c *Context) LookupRoute(request *http.Request) (*MatchedRoute, bool) {
 }
 
 // RouteInfo tries to match a route for this request
-func (c *Context) RouteInfo(request *http.Request) (*MatchedRoute, bool) {
-	if v, ok := context.GetOk(request, ctxMatchedRoute); ok {
-		if val, ok := v.(*MatchedRoute); ok {
-			return val, ok
-		}
+// Returns the matched route, a shallow copy of the request if its context
+// contains the matched router, otherwise the same request, and a bool to
+// indicate if it the request matches one of the routes, if it doesn't
+// then it returns false and nil for the other two return values
+func (c *Context) RouteInfo(request *http.Request) (*MatchedRoute, *http.Request, bool) {
+	var rCtx = request.Context()
+
+	if v, ok := rCtx.Value(ctxMatchedRoute).(*MatchedRoute); ok {
+		return v, request, ok
 	}
 
 	if route, ok := c.LookupRoute(request); ok {
-		context.Set(request, ctxMatchedRoute, route)
-		return route, ok
+		rCtx = stdContext.WithValue(rCtx, ctxMatchedRoute, route)
+		return route, request.WithContext(rCtx), ok
 	}
 
-	return nil, false
+	return nil, nil, false
 }
 
 // ResponseFormat negotiates the response content type
-func (c *Context) ResponseFormat(r *http.Request, offers []string) string {
-	if v, ok := context.GetOk(r, ctxResponseFormat); ok {
-		if val, ok := v.(string); ok {
-			return val
-		}
+// Returns the response format and a shallow copy of the request if its context
+// doesn't contain the response format, otherwise the same request
+func (c *Context) ResponseFormat(r *http.Request, offers []string) (string, *http.Request) {
+	var rCtx = r.Context()
+
+	if v, ok := rCtx.Value(ctxResponseFormat).(string); ok {
+		return v, r
 	}
 
 	format := NegotiateContentType(r, offers, "")
 	if format != "" {
-		context.Set(r, ctxResponseFormat, format)
+		r = r.WithContext(stdContext.WithValue(rCtx, ctxResponseFormat, format))
 	}
-	return format
+	return format, r
 }
 
 // AllowedMethods gets the allowed methods for the path of this request
@@ -352,12 +367,17 @@ func (c *Context) AllowedMethods(request *http.Request) []string {
 }
 
 // Authorize authorizes the request
-func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interface{}, error) {
+// Returns the principal object and a shallow copy of the request when its
+// context doesn't contain the principal, otherwise the same request or an error
+// (the last) if one of the authenticators returns one or an Unauthenticated error
+func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interface{}, *http.Request, error) {
 	if route == nil || len(route.Authenticators) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
-	if v, ok := context.GetOk(request, ctxSecurityPrincipal); ok {
-		return v, nil
+
+	var rCtx = request.Context()
+	if v := rCtx.Value(ctxSecurityPrincipal); v != nil {
+		return v, request, nil
 	}
 
 	var lastError error
@@ -372,38 +392,40 @@ func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interfa
 			}
 			continue
 		}
-		context.Set(request, ctxSecurityPrincipal, usr)
-		context.Set(request, ctxSecurityScopes, route.Scopes[scheme])
-		return usr, nil
+		rCtx = stdContext.WithValue(rCtx, ctxSecurityPrincipal, usr)
+		rCtx = stdContext.WithValue(rCtx, ctxSecurityScopes, route.Scopes[scheme])
+		return usr, request.WithContext(rCtx), nil
 	}
 
 	if lastError != nil {
-		return nil, lastError
+		return nil, nil, lastError
 	}
 
-	return nil, errors.Unauthenticated("invalid credentials")
+	return nil, nil, errors.Unauthenticated("invalid credentials")
 }
 
 // BindAndValidate binds and validates the request
-func (c *Context) BindAndValidate(request *http.Request, matched *MatchedRoute) (interface{}, error) {
-	if v, ok := context.GetOk(request, ctxBoundParams); ok {
-		if val, ok := v.(*validation); ok {
-			debugLog("got cached validation (valid: %t)", len(val.result) == 0)
-			if len(val.result) > 0 {
-				return val.bound, errors.CompositeValidationError(val.result...)
-			}
-			return val.bound, nil
+// Returns the validation map and a shallow copy of the request when its context
+// doesn't contain the validation, otherwise it returns the same request or an
+// CompositeValidationError error
+func (c *Context) BindAndValidate(request *http.Request, matched *MatchedRoute) (interface{}, *http.Request, error) {
+	var rCtx = request.Context()
+
+	if v, ok := rCtx.Value(ctxBoundParams).(*validation); ok {
+		debugLog("got cached validation (valid: %t)", len(v.result) == 0)
+		if len(v.result) > 0 {
+			return v.bound, request, errors.CompositeValidationError(v.result...)
 		}
+		return v.bound, request, nil
 	}
 	result := validateRequest(c, request, matched)
-	if result != nil {
-		context.Set(request, ctxBoundParams, result)
-	}
+	rCtx = stdContext.WithValue(rCtx, ctxBoundParams, result)
+	request = request.WithContext(rCtx)
 	if len(result.result) > 0 {
-		return result.bound, errors.CompositeValidationError(result.result...)
+		return result.bound, request, errors.CompositeValidationError(result.result...)
 	}
 	debugLog("no validation errors found")
-	return result.bound, nil
+	return result.bound, request, nil
 }
 
 // NotFound the default not found responder for when no route has been matched yet
@@ -422,7 +444,8 @@ func (c *Context) Respond(rw http.ResponseWriter, r *http.Request, produces []st
 	// the default producer is last so more specific producers take precedence
 	offers = append(offers, c.api.DefaultProduces())
 
-	format := c.ResponseFormat(r, offers)
+	var format string
+	format, r = c.ResponseFormat(r, offers)
 	rw.Header().Set(runtime.HeaderContentType, format)
 
 	if resp, ok := data.(Responder); ok {

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/internal/testing/petstore"
 	"github.com/go-openapi/runtime/middleware/untyped"
-	"github.com/gorilla/context"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -94,42 +93,49 @@ func TestContextAuthorize(t *testing.T) {
 
 	request, _ := runtime.JSONRequest("GET", "/api/pets", nil)
 
-	v, ok := context.GetOk(request, ctxSecurityPrincipal)
-	assert.False(t, ok)
-	assert.Nil(t, v)
-
-	ri, ok := ctx.RouteInfo(request)
+	ri, reqWithCtx, ok := ctx.RouteInfo(request)
 	assert.True(t, ok)
-	p, err := ctx.Authorize(request, ri)
+	assert.NotNil(t, reqWithCtx)
+
+	request = reqWithCtx
+
+	p, reqWithCtx, err := ctx.Authorize(request, ri)
 	assert.Error(t, err)
 	assert.Nil(t, p)
+	assert.Nil(t, reqWithCtx)
 
-	v, ok = context.GetOk(request, ctxSecurityPrincipal)
-	assert.False(t, ok)
+	v := request.Context().Value(ctxSecurityPrincipal)
 	assert.Nil(t, v)
 
 	request.SetBasicAuth("wrong", "wrong")
-	p, err = ctx.Authorize(request, ri)
+	p, reqWithCtx, err = ctx.Authorize(request, ri)
 	assert.Error(t, err)
 	assert.Nil(t, p)
+	assert.Nil(t, reqWithCtx)
 
-	v, ok = context.GetOk(request, ctxSecurityPrincipal)
-	assert.False(t, ok)
+	v = request.Context().Value(ctxSecurityPrincipal)
 	assert.Nil(t, v)
 
 	request.SetBasicAuth("admin", "admin")
-	p, err = ctx.Authorize(request, ri)
+	p, reqWithCtx, err = ctx.Authorize(request, ri)
 	assert.NoError(t, err)
 	assert.Equal(t, "admin", p)
+	assert.NotNil(t, reqWithCtx)
 
-	v, ok = context.GetOk(request, ctxSecurityPrincipal)
+	// Assign the new returned request to follow with the test
+	request = reqWithCtx
+
+	v, ok = request.Context().Value(ctxSecurityPrincipal).(string)
 	assert.True(t, ok)
 	assert.Equal(t, "admin", v)
 
+	// Once the request context contains the principal the authentication
+	// isn't rechecked
 	request.SetBasicAuth("doesn't matter", "doesn't")
-	pp, rr := ctx.Authorize(request, ri)
+	pp, reqCtx, rr := ctx.Authorize(request, ri)
 	assert.Equal(t, p, pp)
 	assert.Equal(t, err, rr)
+	assert.Equal(t, request, reqCtx)
 }
 
 func TestContextNegotiateContentType(t *testing.T) {
@@ -141,11 +147,10 @@ func TestContextNegotiateContentType(t *testing.T) {
 	// request.Header.Add("Accept", "*/*")
 	request.Header.Add("content-type", "text/html")
 
-	v, ok := context.GetOk(request, ctxBoundParams)
-	assert.False(t, ok)
+	v := request.Context().Value(ctxBoundParams)
 	assert.Nil(t, v)
 
-	ri, _ := ctx.RouteInfo(request)
+	ri, request, _ := ctx.RouteInfo(request)
 
 	res := NegotiateContentType(request, ri.Produces, "")
 	assert.Equal(t, "", res)
@@ -164,22 +169,22 @@ func TestContextBindAndValidate(t *testing.T) {
 	request.Header.Add("content-type", "text/html")
 	request.ContentLength = 1
 
-	v, ok := context.GetOk(request, ctxBoundParams)
-	assert.False(t, ok)
+	v := request.Context().Value(ctxBoundParams)
 	assert.Nil(t, v)
 
-	ri, _ := ctx.RouteInfo(request)
-	data, result := ctx.BindAndValidate(request, ri) // this requires a much more thorough test
+	ri, request, _ := ctx.RouteInfo(request)
+	data, request, result := ctx.BindAndValidate(request, ri) // this requires a much more thorough test
 	assert.NotNil(t, data)
 	assert.NotNil(t, result)
 
-	v, ok = context.GetOk(request, ctxBoundParams)
+	v, ok := request.Context().Value(ctxBoundParams).(*validation)
 	assert.True(t, ok)
 	assert.NotNil(t, v)
 
-	dd, rr := ctx.BindAndValidate(request, ri)
+	dd, rCtx, rr := ctx.BindAndValidate(request, ri)
 	assert.Equal(t, data, dd)
 	assert.Equal(t, result, rr)
+	assert.Equal(t, rCtx, request)
 }
 
 func TestContextRender(t *testing.T) {
@@ -193,7 +198,7 @@ func TestContextRender(t *testing.T) {
 
 	request, _ := http.NewRequest("GET", "pets", nil)
 	request.Header.Set(runtime.HeaderAccept, ct)
-	ri, _ := ctx.RouteInfo(request)
+	ri, request, _ := ctx.RouteInfo(request)
 
 	recorder := httptest.NewRecorder()
 	ctx.Respond(recorder, request, []string{ct}, ri, map[string]interface{}{"name": "hello"})
@@ -207,13 +212,14 @@ func TestContextRender(t *testing.T) {
 	// recorder = httptest.NewRecorder()
 	// assert.Panics(t, func() { ctx.Respond(recorder, request, []string{ct}, ri, map[int]interface{}{1: "hello"}) })
 
+	// Panic when route is nil and there is not a producer for the requested response format
 	recorder = httptest.NewRecorder()
 	request, _ = http.NewRequest("GET", "pets", nil)
-	assert.Panics(t, func() { ctx.Respond(recorder, request, []string{}, ri, map[string]interface{}{"name": "hello"}) })
+	assert.Panics(t, func() { ctx.Respond(recorder, request, []string{}, nil, map[string]interface{}{"name": "hello"}) })
 
 	request, _ = http.NewRequest("GET", "/pets", nil)
 	request.Header.Set(runtime.HeaderAccept, ct)
-	ri, _ = ctx.RouteInfo(request)
+	ri, request, _ = ctx.RouteInfo(request)
 
 	recorder = httptest.NewRecorder()
 	ctx.Respond(recorder, request, []string{ct}, ri, map[string]interface{}{"name": "hello"})
@@ -233,7 +239,7 @@ func TestContextRender(t *testing.T) {
 
 	recorder = httptest.NewRecorder()
 	request, _ = http.NewRequest("DELETE", "/api/pets/1", nil)
-	ri, _ = ctx.RouteInfo(request)
+	ri, request, _ = ctx.RouteInfo(request)
 	ctx.Respond(recorder, request, ri.Produces, ri, nil)
 	assert.Equal(t, 204, recorder.Code)
 }
@@ -248,21 +254,21 @@ func TestContextValidResponseFormat(t *testing.T) {
 	request.Header.Set(runtime.HeaderAccept, ct)
 
 	// check there's nothing there
-	cached, ok := context.GetOk(request, ctxResponseFormat)
+	cached, ok := request.Context().Value(ctxResponseFormat).(string)
 	assert.False(t, ok)
 	assert.Empty(t, cached)
 
 	// trigger the parse
-	mt := ctx.ResponseFormat(request, []string{ct})
+	mt, request := ctx.ResponseFormat(request, []string{ct})
 	assert.Equal(t, ct, mt)
 
 	// check it was cached
-	cached, ok = context.GetOk(request, ctxResponseFormat)
+	cached, ok = request.Context().Value(ctxResponseFormat).(string)
 	assert.True(t, ok)
 	assert.Equal(t, ct, cached)
 
 	// check if the cast works and fetch from cache too
-	mt = ctx.ResponseFormat(request, []string{ct})
+	mt, request = ctx.ResponseFormat(request, []string{ct})
 	assert.Equal(t, ct, mt)
 }
 
@@ -277,22 +283,23 @@ func TestContextInvalidResponseFormat(t *testing.T) {
 	request.Header.Set(runtime.HeaderAccept, ct)
 
 	// check there's nothing there
-	cached, ok := context.GetOk(request, ctxResponseFormat)
+	cached, ok := request.Context().Value(ctxResponseFormat).(string)
 	assert.False(t, ok)
 	assert.Empty(t, cached)
 
 	// trigger the parse
-	mt := ctx.ResponseFormat(request, []string{other})
+	mt, request := ctx.ResponseFormat(request, []string{other})
 	assert.Empty(t, mt)
 
 	// check it was cached
-	cached, ok = context.GetOk(request, ctxResponseFormat)
+	cached, ok = request.Context().Value(ctxResponseFormat).(string)
 	assert.False(t, ok)
 	assert.Empty(t, cached)
 
 	// check if the cast works and fetch from cache too
-	mt = ctx.ResponseFormat(request, []string{other})
+	mt, rCtx := ctx.ResponseFormat(request, []string{other})
 	assert.Empty(t, mt)
+	assert.Equal(t, request, rCtx)
 }
 
 func TestContextValidRoute(t *testing.T) {
@@ -303,20 +310,25 @@ func TestContextValidRoute(t *testing.T) {
 	request, _ := http.NewRequest("GET", "/api/pets", nil)
 
 	// check there's nothing there
-	_, ok := context.GetOk(request, ctxMatchedRoute)
-	assert.False(t, ok)
+	cached := request.Context().Value(ctxMatchedRoute)
+	assert.Nil(t, cached)
 
-	matched, ok := ctx.RouteInfo(request)
+	matched, rCtx, ok := ctx.RouteInfo(request)
 	assert.True(t, ok)
 	assert.NotNil(t, matched)
+	assert.NotNil(t, rCtx)
+	assert.NotEqual(t, request, rCtx)
+
+	request = rCtx
 
 	// check it was cached
-	_, ok = context.GetOk(request, ctxMatchedRoute)
+	_, ok = request.Context().Value(ctxMatchedRoute).(*MatchedRoute)
 	assert.True(t, ok)
 
-	matched, ok = ctx.RouteInfo(request)
+	matched, rCtx, ok = ctx.RouteInfo(request)
 	assert.True(t, ok)
 	assert.NotNil(t, matched)
+	assert.Equal(t, request, rCtx)
 }
 
 func TestContextInvalidRoute(t *testing.T) {
@@ -327,20 +339,22 @@ func TestContextInvalidRoute(t *testing.T) {
 	request, _ := http.NewRequest("DELETE", "pets", nil)
 
 	// check there's nothing there
-	_, ok := context.GetOk(request, ctxMatchedRoute)
-	assert.False(t, ok)
+	cached := request.Context().Value(ctxMatchedRoute)
+	assert.Nil(t, cached)
 
-	matched, ok := ctx.RouteInfo(request)
+	matched, rCtx, ok := ctx.RouteInfo(request)
 	assert.False(t, ok)
 	assert.Nil(t, matched)
+	assert.Nil(t, rCtx)
 
-	// check it was cached
-	_, ok = context.GetOk(request, ctxMatchedRoute)
-	assert.False(t, ok)
+	// check it was not cached
+	cached = request.Context().Value(ctxMatchedRoute)
+	assert.Nil(t, cached)
 
-	matched, ok = ctx.RouteInfo(request)
+	matched, rCtx, ok = ctx.RouteInfo(request)
 	assert.False(t, ok)
 	assert.Nil(t, matched)
+	assert.Nil(t, rCtx)
 }
 
 func TestContextValidContentType(t *testing.T) {
@@ -351,22 +365,27 @@ func TestContextValidContentType(t *testing.T) {
 	request.Header.Set(runtime.HeaderContentType, ct)
 
 	// check there's nothing there
-	_, ok := context.GetOk(request, ctxContentType)
-	assert.False(t, ok)
+	cached := request.Context().Value(ctxContentType)
+	assert.Nil(t, cached)
 
 	// trigger the parse
-	mt, _, err := ctx.ContentType(request)
+	mt, _, rCtx, err := ctx.ContentType(request)
 	assert.NoError(t, err)
 	assert.Equal(t, ct, mt)
+	assert.NotNil(t, rCtx)
+	assert.NotEqual(t, request, rCtx)
+
+	request = rCtx
 
 	// check it was cached
-	_, ok = context.GetOk(request, ctxContentType)
-	assert.True(t, ok)
+	cached = request.Context().Value(ctxContentType)
+	assert.NotNil(t, cached)
 
 	// check if the cast works and fetch from cache too
-	mt, _, err = ctx.ContentType(request)
+	mt, _, rCtx, err = ctx.ContentType(request)
 	assert.NoError(t, err)
 	assert.Equal(t, ct, mt)
+	assert.Equal(t, request, rCtx)
 }
 
 func TestContextInvalidContentType(t *testing.T) {
@@ -377,19 +396,21 @@ func TestContextInvalidContentType(t *testing.T) {
 	request.Header.Set(runtime.HeaderContentType, ct)
 
 	// check there's nothing there
-	_, ok := context.GetOk(request, ctxContentType)
-	assert.False(t, ok)
+	cached := request.Context().Value(ctxContentType)
+	assert.Nil(t, cached)
 
 	// trigger the parse
-	mt, _, err := ctx.ContentType(request)
+	mt, _, rCtx, err := ctx.ContentType(request)
 	assert.Error(t, err)
 	assert.Empty(t, mt)
+	assert.Nil(t, rCtx)
 
 	// check it was not cached
-	_, ok = context.GetOk(request, ctxContentType)
-	assert.False(t, ok)
+	cached = request.Context().Value(ctxContentType)
+	assert.Nil(t, cached)
 
 	// check if the failure continues
-	_, _, err = ctx.ContentType(request)
+	_, _, rCtx, err = ctx.ContentType(request)
 	assert.Error(t, err)
+	assert.Nil(t, rCtx)
 }

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -196,7 +196,7 @@ func TestContextRender(t *testing.T) {
 	ctx := NewContext(spec, api, nil)
 	ctx.router = DefaultRouter(spec, ctx.api)
 
-	request, _ := http.NewRequest("GET", "pets", nil)
+	request, _ := http.NewRequest("GET", "/api/pets", nil)
 	request.Header.Set(runtime.HeaderAccept, ct)
 	ri, request, _ := ctx.RouteInfo(request)
 
@@ -214,10 +214,10 @@ func TestContextRender(t *testing.T) {
 
 	// Panic when route is nil and there is not a producer for the requested response format
 	recorder = httptest.NewRecorder()
-	request, _ = http.NewRequest("GET", "pets", nil)
+	request, _ = http.NewRequest("GET", "/api/pets", nil)
 	assert.Panics(t, func() { ctx.Respond(recorder, request, []string{}, nil, map[string]interface{}{"name": "hello"}) })
 
-	request, _ = http.NewRequest("GET", "/pets", nil)
+	request, _ = http.NewRequest("GET", "/api/pets", nil)
 	request.Header.Set(runtime.HeaderAccept, ct)
 	ri, request, _ = ctx.RouteInfo(request)
 

--- a/middleware/doc.go
+++ b/middleware/doc.go
@@ -20,13 +20,10 @@ Pseudo middleware handler
   	"net/http"
 
   	"github.com/go-openapi/errors"
-  	"github.com/gorilla/context"
   )
 
   func newCompleteMiddleware(ctx *Context) http.Handler {
   	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-  		defer context.Clear(r)
-
   		// use context to lookup routes
   		if matched, ok := ctx.RouteInfo(r); ok {
 

--- a/middleware/operation.go
+++ b/middleware/operation.go
@@ -20,7 +20,11 @@ import "net/http"
 func NewOperationExecutor(ctx *Context) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		// use context to lookup routes
-		route, _ := ctx.RouteInfo(r)
+		route, rCtx, _ := ctx.RouteInfo(r)
+		if rCtx != nil {
+			r = rCtx
+		}
+
 		route.Handler.ServeHTTP(rw, r)
 	})
 }

--- a/middleware/router.go
+++ b/middleware/router.go
@@ -28,7 +28,6 @@ import (
 	"github.com/go-openapi/runtime/middleware/denco"
 	"github.com/go-openapi/spec"
 	"github.com/go-openapi/strfmt"
-	"github.com/gorilla/context"
 )
 
 // RouteParam is a object to capture route params in a framework agnostic way.
@@ -71,9 +70,8 @@ func NewRouter(ctx *Context, next http.Handler) http.Handler {
 	}
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		defer context.Clear(r)
-		if _, ok := ctx.RouteInfo(r); ok {
-			next.ServeHTTP(rw, r)
+		if _, rCtx, ok := ctx.RouteInfo(r); ok {
+			next.ServeHTTP(rw, rCtx)
 			return
 		}
 

--- a/middleware/router_test.go
+++ b/middleware/router_test.go
@@ -167,7 +167,7 @@ func TestRouter_EscapedPath(t *testing.T) {
 
 	mw.ServeHTTP(recorder, request)
 	assert.Equal(t, 200, recorder.Code)
-	ri, _ := context.RouteInfo(request)
+	ri, _, _ := context.RouteInfo(request)
 	if assert.NotNil(t, ri) {
 		if assert.NotNil(t, ri.Params) {
 			assert.Equal(t, "abc/def", ri.Params.Get("id"))

--- a/middleware/security.go
+++ b/middleware/security.go
@@ -18,15 +18,20 @@ import "net/http"
 
 func newSecureAPI(ctx *Context, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		route, _ := ctx.RouteInfo(r)
+		route, rCtx, _ := ctx.RouteInfo(r)
+		if rCtx != nil {
+			r = rCtx
+		}
 		if route != nil && len(route.Authenticators) == 0 {
 			next.ServeHTTP(rw, r)
 			return
 		}
 
-		if _, err := ctx.Authorize(r, route); err != nil {
+		if _, rCtx, err := ctx.Authorize(r, route); err != nil {
 			ctx.Respond(rw, r, route.Produces, route, err)
 			return
+		} else {
+			r = rCtx
 		}
 
 		next.ServeHTTP(rw, r)

--- a/middleware/validation.go
+++ b/middleware/validation.go
@@ -28,12 +28,15 @@ import (
 func newValidation(ctx *Context, next http.Handler) http.Handler {
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		matched, _ := ctx.RouteInfo(r)
+		matched, rCtx, _ := ctx.RouteInfo(r)
+		if rCtx != nil {
+			r = rCtx
+		}
 		if matched == nil {
 			ctx.NotFound(rw, r)
 			return
 		}
-		_, result := ctx.BindAndValidate(r, matched)
+		_, r, result := ctx.BindAndValidate(r, matched)
 
 		if result != nil {
 			ctx.Respond(rw, r, matched.Produces, matched, result)
@@ -114,10 +117,13 @@ func (v *validation) parameters() {
 func (v *validation) contentType() {
 	if len(v.result) == 0 && runtime.HasBody(v.request) {
 		debugLog("validating body content type for %s %s", v.request.Method, v.request.URL.EscapedPath())
-		ct, _, err := v.context.ContentType(v.request)
+		ct, _, req, err := v.context.ContentType(v.request)
 		if err != nil {
 			v.result = append(v.result, err)
+		} else {
+			v.request = req
 		}
+
 		if len(v.result) == 0 {
 			if err := validateContentType(v.route.Consumes, ct); err != nil {
 				v.result = append(v.result, err)
@@ -135,7 +141,8 @@ func (v *validation) contentType() {
 }
 
 func (v *validation) responseFormat() {
-	if str := v.context.ResponseFormat(v.request, v.route.Produces); str == "" && runtime.HasBody(v.request) {
+	if str, rCtx := v.context.ResponseFormat(v.request, v.route.Produces); str == "" && runtime.HasBody(v.request) {
+		v.request = rCtx
 		v.result = append(v.result, errors.InvalidResponseFormat(v.request.Header.Get(runtime.HeaderAccept), v.route.Produces))
 	}
 }


### PR DESCRIPTION
This PR remove the gorilla/context to use the standard context that the `http.Request` instances have attached.

As commented in #47 several function/methods have changed to return one more value, which is the `*http.Request` because that's required in order to modify its context.

NOTE that I've read the guidelines for contributing, but I think that's easy to review the changes spread with several commits of logical units, than squash all of them into one to fulfill with the requirement of after each commit the test suite should be passing. If you want me to squash before reviewing let me know, otherwise I could squash before everything is OK to merge and at that time I will capitalize the summary of the commit message, too.