### PR TITLE
Treat an empty accept header like Accept: */*.

### DIFF
--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -152,11 +152,8 @@ func TestContextNegotiateContentType(t *testing.T) {
 
 	ri, request, _ := ctx.RouteInfo(request)
 
-	res := NegotiateContentType(request, ri.Produces, "")
-	assert.Equal(t, "", res)
-
-	res2 := NegotiateContentType(request, ri.Produces, "text/plain")
-	assert.Equal(t, "text/plain", res2)
+	res := NegotiateContentType(request, ri.Produces, "text/plain")
+	assert.Equal(t, ri.Produces[0], res)
 }
 
 func TestContextBindAndValidate(t *testing.T) {
@@ -215,6 +212,7 @@ func TestContextRender(t *testing.T) {
 	// Panic when route is nil and there is not a producer for the requested response format
 	recorder = httptest.NewRecorder()
 	request, _ = http.NewRequest("GET", "/api/pets", nil)
+	request.Header.Set(runtime.HeaderAccept, "text/xml")
 	assert.Panics(t, func() { ctx.Respond(recorder, request, []string{}, nil, map[string]interface{}{"name": "hello"}) })
 
 	request, _ = http.NewRequest("GET", "/api/pets", nil)

--- a/middleware/negotiate.go
+++ b/middleware/negotiate.go
@@ -49,6 +49,10 @@ func NegotiateContentType(r *http.Request, offers []string, defaultOffer string)
 	bestWild := 3
 	specs := header.ParseAccept(r.Header, "Accept")
 	for _, offer := range normalizeOffers(offers) {
+		// No Accept header: just return the first offer.
+		if len(specs) == 0 {
+			return offer
+		}
 		for _, spec := range specs {
 			switch {
 			case spec.Q == 0.0:

--- a/middleware/negotiate_test.go
+++ b/middleware/negotiate_test.go
@@ -70,3 +70,12 @@ func TestNegotiateContentType(t *testing.T) {
 		}
 	}
 }
+
+func TestNegotiateContentTypeNoAcceptHeader(t *testing.T) {
+	r := &http.Request{Header: http.Header{}}
+	offers := []string{"application/json", "text/xml"}
+	actual := NegotiateContentType(r, offers, "")
+	if actual != "application/json" {
+		t.Errorf("NegotiateContentType(empty, %#v, empty)=%q, want %q", offers, actual, "application/json")
+	}
+}


### PR DESCRIPTION
Closes #55.

Signed-off-by: Jacob Baskin <jacob.baskin@gmail.com>