### PR TITLE
Feature: Add support for Authz hook

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -15,8 +15,10 @@
 package runtime
 
 import (
-	"github.com/go-openapi/strfmt"
 	"io"
+	"net/http"
+
+	"github.com/go-openapi/strfmt"
 )
 
 // OperationHandlerFunc an adapter for a function to the OperationHandler interface
@@ -75,6 +77,21 @@ func (f AuthenticatorFunc) Authenticate(params interface{}) (bool, interface{}, 
 // request data and translate that into a valid principal object or an error
 type Authenticator interface {
 	Authenticate(interface{}) (bool, interface{}, error)
+}
+
+// AuthorizerFunc turns a function into an authorizer
+type AuthorizerFunc func(*http.Request, interface{}) error
+
+// Authorize authorizes the processing of the request for the principal
+func (f AuthorizerFunc) Authorize(r *http.Request, principal interface{}) error {
+	return f(r, principal)
+}
+
+// Authorizer represents an authorization strategy
+// implementations of Authorizer know how to authorize the principal object
+// using the request data and returns error if unauthorized
+type Authorizer interface {
+	Authorize(*http.Request, interface{}) error
 }
 
 // Validatable types implementing this interface allow customizing their validation

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -172,6 +172,9 @@ func (r *routableUntypedAPI) ProducersFor(mediaTypes []string) map[string]runtim
 func (r *routableUntypedAPI) AuthenticatorsFor(schemes map[string]spec.SecurityScheme) map[string]runtime.Authenticator {
 	return r.api.AuthenticatorsFor(schemes)
 }
+func (r *routableUntypedAPI) Authorizer() runtime.Authorizer {
+	return r.api.Authorizer()
+}
 func (r *routableUntypedAPI) Formats() strfmt.Registry {
 	return r.api.Formats()
 }
@@ -391,6 +394,11 @@ func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interfa
 				lastError = err
 			}
 			continue
+		}
+		if route.Authorizer != nil {
+			if err := route.Authorizer.Authorize(request, usr); err != nil {
+				return nil, nil, errors.New(http.StatusForbidden, err.Error())
+			}
 		}
 		rCtx = stdContext.WithValue(rCtx, ctxSecurityPrincipal, usr)
 		rCtx = stdContext.WithValue(rCtx, ctxSecurityScopes, route.Scopes[scheme])

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -131,6 +131,32 @@ func TestContextAuthorize(t *testing.T) {
 	assert.Equal(t, request, reqCtx)
 }
 
+func TestContextAuthorize_WithAuthorizer(t *testing.T) {
+	spec, api := petstore.NewAPI(t)
+	ctx := NewContext(spec, api, nil)
+	ctx.router = DefaultRouter(spec, ctx.api)
+
+	request, _ := runtime.JSONRequest("POST", "/api/pets", nil)
+
+	ri, reqWithCtx, ok := ctx.RouteInfo(request)
+	assert.True(t, ok)
+	assert.NotNil(t, reqWithCtx)
+
+	request = reqWithCtx
+
+	request.SetBasicAuth("topuser", "topuser")
+	p, reqWithCtx, err := ctx.Authorize(request, ri)
+	assert.Error(t, err)
+	assert.Nil(t, p)
+	assert.Nil(t, reqWithCtx)
+
+	request.SetBasicAuth("admin", "admin")
+	p, reqWithCtx, err = ctx.Authorize(request, ri)
+	assert.NoError(t, err)
+	assert.Equal(t, "admin", p)
+	assert.NotNil(t, reqWithCtx)
+}
+
 func TestContextNegotiateContentType(t *testing.T) {
 	spec, api := petstore.NewAPI(t)
 	ctx := NewContext(spec, api, nil)
@@ -233,6 +259,7 @@ func TestContextRender(t *testing.T) {
 	ri, request, _ = ctx.RouteInfo(request)
 	ctx.Respond(recorder, request, ri.Produces, ri, nil)
 	assert.Equal(t, 204, recorder.Code)
+
 }
 
 func TestContextValidResponseFormat(t *testing.T) {

--- a/middleware/router.go
+++ b/middleware/router.go
@@ -92,6 +92,7 @@ type RoutableAPI interface {
 	ConsumersFor([]string) map[string]runtime.Consumer
 	ProducersFor([]string) map[string]runtime.Producer
 	AuthenticatorsFor(map[string]spec.SecurityScheme) map[string]runtime.Authenticator
+	Authorizer() runtime.Authorizer
 	Formats() strfmt.Registry
 	DefaultProduces() string
 	DefaultConsumes() string
@@ -152,6 +153,7 @@ type routeEntry struct {
 	Formats        strfmt.Registry
 	Binder         *untypedRequestBinder
 	Authenticators map[string]runtime.Authenticator
+	Authorizer     runtime.Authorizer
 	Scopes         map[string][]string
 }
 
@@ -247,6 +249,7 @@ func (d *defaultRouteBuilder) AddRoute(method, path string, operation *spec.Oper
 			Formats:        d.api.Formats(),
 			Binder:         newUntypedRequestBinder(parameters, d.spec.Spec(), d.api.Formats()),
 			Authenticators: d.api.AuthenticatorsFor(definitions),
+			Authorizer:     d.api.Authorizer(),
 			Scopes:         scopes,
 		})
 		d.records[mn] = append(d.records[mn], record)

--- a/middleware/untyped/api.go
+++ b/middleware/untyped/api.go
@@ -57,6 +57,7 @@ type API struct {
 	consumers       map[string]runtime.Consumer
 	producers       map[string]runtime.Producer
 	authenticators  map[string]runtime.Authenticator
+	authorizer      runtime.Authorizer
 	operations      map[string]map[string]runtime.OperationHandler
 	ServeError      func(http.ResponseWriter, *http.Request, error)
 	Models          map[string]func() interface{}
@@ -103,6 +104,11 @@ func (d *API) RegisterAuth(scheme string, handler runtime.Authenticator) {
 		d.authenticators = make(map[string]runtime.Authenticator)
 	}
 	d.authenticators[scheme] = handler
+}
+
+// RegisterAuthorizer registers an authorizer handler in this api
+func (d *API) RegisterAuthorizer(handler runtime.Authorizer) {
+	d.authorizer = handler
 }
 
 // RegisterConsumer registers a consumer for a media type.
@@ -176,6 +182,11 @@ func (d *API) AuthenticatorsFor(schemes map[string]spec.SecurityScheme) map[stri
 		}
 	}
 	return result
+}
+
+// AuthorizersFor returns the registered authorizer
+func (d *API) Authorizer() runtime.Authorizer {
+	return d.authorizer
 }
 
 // Validate validates this API for any missing items

--- a/middleware/untyped/api_test.go
+++ b/middleware/untyped/api_test.go
@@ -16,6 +16,7 @@ package untyped
 
 import (
 	"io"
+	"net/http"
 	"sort"
 	"testing"
 
@@ -29,6 +30,10 @@ import (
 
 func stubAutenticator() runtime.Authenticator {
 	return runtime.AuthenticatorFunc(func(_ interface{}) (bool, interface{}, error) { return false, nil, nil })
+}
+
+func stubAuthorizer() runtime.Authorizer {
+	return runtime.AuthorizerFunc(func(_ *http.Request, _ interface{}) error { return nil })
 }
 
 type stubConsumer struct {
@@ -63,7 +68,9 @@ func TestUntypedAPIRegistrations(t *testing.T) {
 	api.RegisterProducer("application/yada-2", new(stubProducer))
 	api.RegisterOperation("get", "/{someId}", new(stubOperationHandler))
 	api.RegisterAuth("basic", stubAutenticator())
+	api.RegisterAuthorizer(stubAuthorizer())
 
+	assert.NotNil(t, api.authorizer)
 	assert.NotEmpty(t, api.authenticators)
 
 	_, ok := api.authenticators["basic"]
@@ -78,6 +85,9 @@ func TestUntypedAPIRegistrations(t *testing.T) {
 	assert.True(t, ok)
 	_, ok = api.operations["GET"]["/{someId}"]
 	assert.True(t, ok)
+
+	authorizer := api.Authorizer()
+	assert.NotNil(t, authorizer)
 
 	h, ok := api.OperationHandlerFor("get", "/{someId}")
 	assert.True(t, ok)

--- a/security/authorizer.go
+++ b/security/authorizer.go
@@ -1,0 +1,27 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"net/http"
+
+	"github.com/go-openapi/runtime"
+)
+
+// Authorized provides a default implementation of the Authorizer interface where all
+// requests are authorized (successful)
+func Authorized() runtime.Authorizer {
+	return runtime.AuthorizerFunc(func(_ *http.Request, _ interface{}) error { return nil })
+}

--- a/security/authorizer_test.go
+++ b/security/authorizer_test.go
@@ -1,0 +1,28 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package security
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestAuthorized(t *testing.T) {
+	authorizer := Authorized()
+
+	err := authorizer.Authorize(nil, nil)
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
Adds Authorizer interface and wires in the ability to configure an
Authorizer into an API, and the execution of the Authorizer as part
of Authorize which previously only implemented authentication.

The Authorizer will provide the ability to include an implementation
for authorizing a request for a given authenticated principal.

resolves: #51 