### PR TITLE
Manage logger in a consistent way.

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -1,0 +1,12 @@
+package logger
+
+import "os"
+
+type Logger interface {
+	Printf(format string, args ...interface{})
+	Debugf(format string, args ...interface{})
+}
+
+func DebugEnabled() bool {
+	return os.Getenv("SWAGGER_DEBUG") != "" || os.Getenv("DEBUG") != ""
+}

--- a/logger/standard.go
+++ b/logger/standard.go
@@ -1,0 +1,16 @@
+package logger
+
+import (
+	"fmt"
+	"os"
+)
+
+type StandardLogger struct{}
+
+func (StandardLogger) Printf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stdout, format, args...)
+}
+
+func (StandardLogger) Debugf(format string, args ...interface{}) {
+	fmt.Fprintf(os.Stderr, format, args...)
+}

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -16,9 +16,7 @@ package middleware
 
 import (
 	stdContext "context"
-	"log"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 
@@ -26,6 +24,7 @@ import (
 	"github.com/go-openapi/errors"
 	"github.com/go-openapi/loads"
 	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/logger"
 	"github.com/go-openapi/runtime/middleware/untyped"
 	"github.com/go-openapi/runtime/security"
 	"github.com/go-openapi/spec"
@@ -33,11 +32,12 @@ import (
 )
 
 // Debug when true turns on verbose logging
-var Debug = os.Getenv("SWAGGER_DEBUG") != "" || os.Getenv("DEBUG") != ""
+var Debug = logger.DebugEnabled()
+var Logger logger.Logger = logger.StandardLogger{}
 
 func debugLog(format string, args ...interface{}) {
 	if Debug {
-		log.Printf(format, args...)
+		Logger.Printf(format, args...)
 	}
 }
 


### PR DESCRIPTION
- Allow clients to set their own loggers in a consistent way.
- Allow clients to set ther debug level in a consistent way.

This change should be backwards compatible:

- It keeps the Debug variables public to not break existing integrations.
- It defines a standard logger with the same behavior the old code had.

Signed-off-by: David Calavera <david.calavera@gmail.com>