### PR TITLE
Add a way to get current query params for a ClientRequest

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -275,6 +275,15 @@ func (r *request) SetQueryParam(name string, values ...string) error {
 	return nil
 }
 
+// GetQueryParams returns a copy of all query params currently set for the request
+func (r *request) GetQueryParams() url.Values {
+	var result = make(url.Values)
+	for key, value := range r.query {
+		result[key] = append([]string{}, value...)
+	}
+	return result
+}
+
 // SetFormParam adds a forn param to the request
 // when there is only 1 value provided for the varargs, it will set it.
 // when there are several values provided for the varargs it will add it (no overriding)

--- a/client_request.go
+++ b/client_request.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"io"
+	"net/url"
 	"time"
 
 	"github.com/go-openapi/strfmt"
@@ -44,6 +45,8 @@ type ClientRequest interface {
 	SetFormParam(string, ...string) error
 
 	SetPathParam(string, string) error
+
+	GetQueryParams() url.Values
 
 	SetFileParam(string, ...NamedReadCloser) error
 

--- a/client_request_test.go
+++ b/client_request_test.go
@@ -16,6 +16,7 @@ package runtime
 
 import (
 	"net/http"
+	"net/url"
 	"testing"
 	"time"
 
@@ -52,6 +53,8 @@ func (t *trw) SetBodyParam(body interface{}) error {
 func (t *trw) SetTimeout(timeout time.Duration) error {
 	return nil
 }
+
+func (t *trw) GetQueryParams() url.Values { return nil }
 
 func (t *trw) GetMethod() string { return "" }
 


### PR DESCRIPTION
This will be useful in ClientAuthInfoWriters which are dependent on
query parameters.