### PR TITLE
fix swagger spec of Petstore20

### DIFF
--- a/internal/testing/data.go
+++ b/internal/testing/data.go
@@ -341,7 +341,6 @@ const PetStore20 = `{
   },
   "definitions": {
     "Category": {
-      "id": "Category",
       "properties": {
         "id": {
           "format": "int64",
@@ -353,7 +352,6 @@ const PetStore20 = `{
       }
     },
     "Pet": {
-      "id": "Pet",
       "properties": {
         "category": {
           "$ref": "#/definitions/Category"
@@ -408,7 +406,6 @@ const PetStore20 = `{
       ]
     },
     "Tag": {
-      "id": "Tag",
       "properties": {
         "id": {
           "format": "int64",
@@ -617,7 +614,6 @@ const RootPetStore20 = `{
   },
   "definitions": {
     "Category": {
-      "id": "Category",
       "properties": {
         "id": {
           "format": "int64",
@@ -629,7 +625,6 @@ const RootPetStore20 = `{
       }
     },
     "Pet": {
-      "id": "Pet",
       "properties": {
         "category": {
           "$ref": "#/definitions/Category"
@@ -684,7 +679,6 @@ const RootPetStore20 = `{
       ]
     },
     "Tag": {
-      "id": "Tag",
       "properties": {
         "id": {
           "format": "int64",


### PR DESCRIPTION
There were some "ids" in the spec that changes the resolution scope of references to other non-existing files when the references were meant to point to schemas in the same file