### PR TITLE
add a keepalive roundtripper

### DIFF
--- a/client/keepalive.go
+++ b/client/keepalive.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"sync/atomic"
+)
+
+// KeepAliveTransport drains the remaining body from a response
+// so that go will reuse the TCP connections.
+// This is not enabled by default because there are servers where
+// the response never gets closed and that would make the code hang forever.
+// So instead it's provided as a http client middleware that can be used to override
+// any request.
+func KeepAliveTransport(rt http.RoundTripper) http.RoundTripper {
+	return &keepAliveTransport{wrapped: rt}
+}
+
+type keepAliveTransport struct {
+	wrapped http.RoundTripper
+}
+
+func (k *keepAliveTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	resp, err := k.wrapped.RoundTrip(r)
+	if err != nil {
+		return resp, err
+	}
+	resp.Body = &drainingReadCloser{rdr: resp.Body}
+	return resp, nil
+}
+
+type drainingReadCloser struct {
+	rdr     io.ReadCloser
+	seenEOF uint32
+}
+
+func (d *drainingReadCloser) Read(p []byte) (n int, err error) {
+	n, err = d.rdr.Read(p)
+	if err == io.EOF || n == 0 {
+		atomic.StoreUint32(&d.seenEOF, 1)
+	}
+	return
+}
+
+func (d *drainingReadCloser) Close() error {
+	// drain buffer
+	if atomic.LoadUint32(&d.seenEOF) != 1 {
+		//#nosec
+		io.Copy(ioutil.Discard, d.rdr)
+	}
+	return d.rdr.Close()
+}

--- a/client/keepalive_test.go
+++ b/client/keepalive_test.go
@@ -1,0 +1,73 @@
+package client
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func newCountingReader(rdr io.Reader, readOnce bool) *countingReadCloser {
+	return &countingReadCloser{
+		rdr:      rdr,
+		readOnce: readOnce,
+	}
+}
+
+type countingReadCloser struct {
+	rdr         io.Reader
+	readOnce    bool
+	readCalled  int
+	closeCalled int
+}
+
+func (c *countingReadCloser) Read(b []byte) (int, error) {
+	c.readCalled++
+	if c.readCalled > 1 && c.readOnce {
+		return 0, io.EOF
+	}
+	return c.rdr.Read(b)
+}
+
+func (c *countingReadCloser) Close() error {
+	c.closeCalled++
+	return nil
+}
+
+func TestDrainingReadCloser(t *testing.T) {
+	rdr := newCountingReader(bytes.NewBufferString("There are many things to do"), false)
+	prevDisc := ioutil.Discard
+	disc := bytes.NewBuffer(nil)
+	ioutil.Discard = disc
+	defer func() { ioutil.Discard = prevDisc }()
+
+	buf := make([]byte, 5)
+	ts := &drainingReadCloser{rdr: rdr}
+	ts.Read(buf)
+	ts.Close()
+	assert.Equal(t, "There", string(buf))
+	assert.Equal(t, " are many things to do", disc.String())
+	assert.Equal(t, 3, rdr.readCalled)
+	assert.Equal(t, 1, rdr.closeCalled)
+}
+
+func TestDrainingReadCloser_SeenEOF(t *testing.T) {
+	rdr := newCountingReader(bytes.NewBufferString("There are many things to do"), true)
+	prevDisc := ioutil.Discard
+	disc := bytes.NewBuffer(nil)
+	ioutil.Discard = disc
+	defer func() { ioutil.Discard = prevDisc }()
+
+	buf := make([]byte, 5)
+	ts := &drainingReadCloser{rdr: rdr}
+	ts.Read(buf)
+	_, err := ts.Read(nil)
+	assert.Equal(t, io.EOF, err)
+	ts.Close()
+	assert.Equal(t, string(buf), "There")
+	assert.Equal(t, disc.String(), "")
+	assert.Equal(t, 2, rdr.readCalled)
+	assert.Equal(t, 1, rdr.closeCalled)
+}

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -277,6 +277,33 @@ func (r *Runtime) selectScheme(schemes []string) string {
 	return scheme
 }
 
+// EnableConnectionReuse drains the remaining body from a response
+// so that go will reuse the TCP connections.
+//
+// This is not enabled by default because there are servers where
+// the response never gets closed and that would make the code hang forever.
+// So instead it's provided as a http client middleware that can be used to override
+// any request.
+func (r *Runtime) EnableConnectionReuse() {
+	if r.client != nil {
+		tr := r.Transport
+		if tr == nil {
+			tr = http.DefaultTransport
+		}
+		r.Transport = KeepAliveTransport(tr)
+		return
+	}
+
+	tr := r.client.Transport
+	if tr == nil {
+		tr = r.Transport
+		if tr == nil {
+			tr = http.DefaultTransport
+		}
+	}
+	r.client.Transport = KeepAliveTransport(tr)
+}
+
 // Submit a request and when there is a body on success it will turn that into the result
 // all other things are turned into an api error for swagger which retains the status code
 func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error) {


### PR DESCRIPTION
Adds a roundtripper that drains the body so that go will reuse tcp connection on keep alive connections.