### PR TITLE
feat: Allows overriding of the client operation

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -196,7 +196,7 @@ type Runtime struct {
 	clientOnce *sync.Once
 	client     *http.Client
 	schemes    []string
-	do         func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
+	Do         func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
 }
 
 // New creates a new default runtime for a swagger api runtime.Client
@@ -233,7 +233,7 @@ func New(host, basePath string, schemes []string) *Runtime {
 	if len(schemes) > 0 {
 		rt.schemes = schemes
 	}
-	rt.do = ctxhttp.Do
+	rt.Do = ctxhttp.Do
 	return &rt
 }
 
@@ -357,10 +357,10 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 	if client == nil {
 		client = r.client
 	}
-	if r.do == nil {
-		r.do = ctxhttp.Do
+	if r.Do == nil {
+		r.Do = ctxhttp.Do
 	}
-	res, err := r.do(ctx, client, req) // make requests, by default follows 10 redirects before failing
+	res, err := r.Do(ctx, client, req) // make requests, by default follows 10 redirects before failing
 	if err != nil {
 		return nil, err
 	}

--- a/client/runtime_test.go
+++ b/client/runtime_test.go
@@ -607,7 +607,7 @@ func TestRuntime_ContentTypeCanary(t *testing.T) {
 
 	hu, _ := url.Parse(server.URL)
 	rt := New(hu.Host, "/", []string{"http"})
-	rt.do = nil
+	rt.Do = nil
 	res, err := rt.Submit(&runtime.ClientOperation{
 		ID:          "getTasks",
 		Method:      "GET",
@@ -739,7 +739,7 @@ func TestRuntime_OverrideClientOperation(t *testing.T) {
 	assert.Equal(t, 0, i)
 
 	var seen *http.Client
-	rt.do = func(_ context.Context, cl *http.Client, _ *http.Request) (*http.Response, error) {
+	rt.Do = func(_ context.Context, cl *http.Client, _ *http.Request) (*http.Response, error) {
 		seen = cl
 		res := new(http.Response)
 		res.StatusCode = 200


### PR DESCRIPTION
Export the `Do` function on the `runtime` struct to allow overidding when the library is used in another program.

I use this technique to set the bearer token on each request once authenticated

```go
rt.Do = authClient.Do
...
func (r *AuthenticatedClient) Do(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error) {
	if client == nil {
		client = r.HttpClient
	}

	if len(r.AccessToken) > 0 {
		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", r.AccessToken))
	}

	if logging.IsDebugOrHigher() {
		dump, errDump := httputil.DumpRequestOut(req, true)
		if errDump != nil {
			log.Fatal(errDump)
		}

		log.Printf("[DEBUG] %s %s", req.URL.String(), string(dump))
	}

	resp, err := client.Do(req.WithContext(ctx))
	// If we got an error, and the context has been canceled,
	// the context's error is probably more useful.
	if err != nil {
		select {
		case <-ctx.Done():
			err = ctx.Err()
		default:
		}
		return nil, err
	}

	if logging.IsDebugOrHigher() {
		dump, errDump := httputil.DumpResponse(resp, true)
		if errDump != nil {
			log.Fatal(errDump)
		}

		log.Printf("[DEBUG] %s %s", req.URL.String(), string(dump))
	}

	return resp, err
}
```