### PR TITLE
Added map access check to avoid panic in case producer isn't registered

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -340,6 +340,10 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 		}
 	}
 
+    if _, ok := r.Producers[cmt]; !ok {
+        return nil, fmt.Errorf("none of producers: %v registered. try %s",r.Producers, cmt)
+    }
+
 	req, err := request.buildHTTP(cmt, r.BasePath, r.Producers, r.Formats, auth)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Encountered panic due to unregistered and/or mis-spelled producer in client. 