### PR TITLE
Allow optional authentication

### DIFF
--- a/middleware/route_authenticator_test.go
+++ b/middleware/route_authenticator_test.go
@@ -201,6 +201,8 @@ func TestAuthenticateOptional(t *testing.T) {
 	}
 	ra2 := RouteAuthenticator{
 		allowAnonymous: true,
+		Schemes:        []string{""},
+		Scopes:         map[string][]string{"": []string{}},
 	}
 
 	ra3 := RouteAuthenticator{

--- a/middleware/router.go
+++ b/middleware/router.go
@@ -244,7 +244,7 @@ type RouteAuthenticators []RouteAuthenticator
 // AllowsAnonymous returns true when there is an authenticator that means optional auth
 func (ras RouteAuthenticators) AllowsAnonymous() bool {
 	for _, ra := range ras {
-		if len(ra.Authenticator) == 0 && len(ra.Schemes) == 0 {
+		if ra.AllowsAnonymous() {
 			return true
 		}
 	}


### PR DESCRIPTION
The goal of this change is to allow for optional authentication.

My assumption is that the security spec below should allow for optional authentication:
```yaml
security:
  - {}
  - SomeOtherAuthenticationType: []
```

In the default route builder's [`buildAuthenticators` method](https://github.com/go-openapi/runtime/blob/c0cae94704c76c8643896d8054080f91e920105b/middleware/router.go#L440-L465), the first requirement in the spec above results in a route authenticator with (among other things) these schemes: `[]string{"}`.

The current [`AllowsAnonymous` method](https://github.com/go-openapi/runtime/blob/c0cae94704c76c8643896d8054080f91e920105b/middleware/router.go#L440-L465) for a slice of route authenticators only returns `true` if each authenticator has a zero length `Schemes`.

So, while `ra.AllowsAnonymous()` returns `true` for the first requirement in the spec above, `ras.AllowsAnonymous()` returns `false` for the slice.

I've updated the `TestAuthenticateOptional` test so that the shape of the anonymous route authenticator is closer to the one built from the spec above.  For this test to pass, the `AllowsAnonymous` method on the authenticators slice method calls the same method on the individual route authenticators.

See go-swagger/go-swagger#1446 and go-openapi/runtime#98.
