### PR TITLE
add a special case for multipart form data when checking for producers

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -342,9 +342,9 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 		}
 	}
 
-    if _, ok := r.Producers[cmt]; !ok {
-        return nil, fmt.Errorf("none of producers: %v registered. try %s",r.Producers, cmt)
-    }
+	if _, ok := r.Producers[cmt]; !ok && cmt != runtime.MultipartFormMime {
+		return nil, fmt.Errorf("none of producers: %v registered. try %s", r.Producers, cmt)
+	}
 
 	req, err := request.buildHTTP(cmt, r.BasePath, r.Producers, r.Formats, auth)
 	if err != nil {


### PR DESCRIPTION
Hello, I added a special case to check for the multipart form data mime type. If this isn't here then uploading files with multipart form data is broken!