### PR TITLE
Move from x/net/context to context in the client code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ install:
 - go get -u gopkg.in/matm/v1/gocov-html
 - go get -u github.com/cee-dub/go-junit-report
 - go get -u github.com/stretchr/testify/assert
-- go get -u golang.org/x/net/context
 - go get -u gopkg.in/yaml.v2
 - go get -u github.com/go-openapi/analysis
 - go get -u github.com/go-openapi/errors

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -15,6 +15,7 @@
 package client
 
 import (
+	"context"
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
@@ -29,9 +30,6 @@ import (
 	"strings"
 	"sync"
 	"time"
-
-	"golang.org/x/net/context"
-	"golang.org/x/net/context/ctxhttp"
 
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/logger"
@@ -196,7 +194,6 @@ type Runtime struct {
 	clientOnce *sync.Once
 	client     *http.Client
 	schemes    []string
-	do         func(ctx context.Context, client *http.Client, req *http.Request) (*http.Response, error)
 }
 
 // New creates a new default runtime for a swagger api runtime.Client
@@ -235,7 +232,6 @@ func New(host, basePath string, schemes []string) *Runtime {
 	if len(schemes) > 0 {
 		rt.schemes = schemes
 	}
-	rt.do = ctxhttp.Do
 	return &rt
 }
 
@@ -391,10 +387,8 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 	if client == nil {
 		client = r.client
 	}
-	if r.do == nil {
-		r.do = ctxhttp.Do
-	}
-	res, err := r.do(ctx, client, req) // make requests, by default follows 10 redirects before failing
+	req = req.WithContext(ctx)
+	res, err := client.Do(req) // make requests, by default follows 10 redirects before failing
 	if err != nil {
 		return nil, err
 	}

--- a/client_operation.go
+++ b/client_operation.go
@@ -17,7 +17,7 @@ package runtime
 import (
 	"net/http"
 
-	"golang.org/x/net/context"
+	"context"
 )
 
 // ClientOperation represents the context for a swagger operation to be submitted to the transport


### PR DESCRIPTION
I had to delete TestRuntime_OverrideClientOperation as it's no longer supported behavior and I couldn't see anywhere where it's used. 