### PR TITLE
avoid copying into a nil writer

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -176,8 +176,7 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 					if err != nil {
 						pw.CloseWithError(err)
 						log.Println(err)
-					}
-					if _, err := io.Copy(wrtr, fi); err != nil {
+					} else if _, err := io.Copy(wrtr, fi); err != nil {
 						pw.CloseWithError(err)
 						log.Println(err)
 					}


### PR DESCRIPTION
This is for https://github.com/go-openapi/runtime/issues/110

I am not sure if you prefer leaving the loop instead. As the original code was not breaking out from the loop after the error in the first block, I didn't add 'break' to that block but instead just avoid invoking io.Copy.
