### PR TITLE
Add support for getting headers to ClientRequest

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -286,6 +286,11 @@ func (r *request) SetHeaderParam(name string, values ...string) error {
 	return nil
 }
 
+// GetHeaderParams returns the all headers currently set for the request
+func (r *request) GetHeaderParams() http.Header {
+	return r.header
+}
+
 // SetQueryParam adds a query param to the request
 // when there is only 1 value provided for the varargs, it will set it.
 // when there are several values provided for the varargs it will add it (no overriding)

--- a/client_request.go
+++ b/client_request.go
@@ -17,6 +17,7 @@ package runtime
 import (
 	"io"
 	"io/ioutil"
+	"net/http"
 	"net/url"
 	"time"
 
@@ -40,6 +41,8 @@ type ClientRequestWriter interface {
 // add information to a swagger client request
 type ClientRequest interface {
 	SetHeaderParam(string, ...string) error
+	
+	GetHeaderParams() http.Header
 
 	SetQueryParam(string, ...string) error
 


### PR DESCRIPTION
This is useful for things like implementing a `ClientAuthInfoWriterFunc` that [signs requests](https://tools.ietf.org/html/draft-cavage-http-signatures-09), for example.

This was just quickly thrown together in the GitHub UI. I'll do proper software engineering (e.g., tests) when I get a chance later.