### PR TITLE
Remove bytecopy from GetBody

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -213,9 +213,6 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 				return nil, err
 			}
 
-			if _, err := r.buf.Write(b.Bytes()); err != nil {
-				return nil, err
-			}
 			return ioutil.NopCloser(&b), nil
 		}
 


### PR DESCRIPTION
req.Body is already populated, and this, even on the first call, will write the payload again.  It seems the solution is to just remove the byte copy all together.

Also adds a test guarding against the bug.  Any feedback on the approach or style is appreciated :)

Closes https://github.com/go-openapi/runtime/issues/130