### PR TITLE
Add additional context to ReadResponse errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ install:
 - go get -u github.com/go-openapi/strfmt
 - go get -u github.com/go-openapi/validate
 - go get -u github.com/docker/go-units
+- go get -u github.com/pkg/errors
 language: go
 notifications:
   slack:

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -35,6 +35,7 @@ import (
 	"github.com/go-openapi/runtime/logger"
 	"github.com/go-openapi/runtime/middleware"
 	"github.com/go-openapi/strfmt"
+	"github.com/pkg/errors"
 )
 
 // TLSClientOptions to configure client authentication with mutual TLS
@@ -421,7 +422,12 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 			return nil, fmt.Errorf("no consumer: %q", ct)
 		}
 	}
-	return readResponse.ReadResponse(response{res}, cons)
+
+	resp, err := readResponse.ReadResponse(response{res}, cons)
+	if err != nil {
+		return nil, errors.WithMessagef(err, "[%v %v][%d] %v Content-Type: %+v", operation.Method, operation.PathPattern, res.StatusCode, operation.ID, res.Header.Get("Content-Type"))
+	}
+	return resp, nil
 }
 
 // SetDebug changes the debug flag.

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/go-openapi/validate v0.18.0
 	github.com/google/uuid v1.1.1 // indirect
 	github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe // indirect
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/objx v0.1.1 // indirect
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/crypto v0.0.0-20190320223903-b7391e95e576 // indirect

--- a/go.sum
+++ b/go.sum
@@ -62,6 +62,8 @@ github.com/mailru/easyjson v0.0.0-20190312143242-1de009706dbe/go.mod h1:C1wdFJiN
 github.com/mitchellh/mapstructure v1.1.2 h1:fmNYVwqnSfB9mZU6OS2O6GsXM+wcskZDuKQzvN1EDeE=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
When there is an issue reading a response, because the API is sending an unexpected content type for example, the error that ends up bubbling up is often something that isn’t very useful. e.g.

``&{0 } (*models.Error) is not supported by the TextConsumer, can be resolved by supporting TextUnmarshaler interfac``

This wraps the errors that come out of readResponse.ReadResponse and add a few pieces of key information that can provide more context to what’s going on, like the statusCode and the Content-Type.