### PR TITLE
Issue: #1917 in github.com/go-swagger/go-swagger: Don't attempt to unmarshal empty response bodies to prevent panic.

### DIFF
--- a/text.go
+++ b/text.go
@@ -39,6 +39,12 @@ func TextConsumer() Consumer {
 		}
 		b := buf.Bytes()
 
+		// If the buffer is empty, no need to unmarshal it, which causes a panic.
+		if len(b) == 0 {
+			data = ""
+			return nil
+		}
+
 		if tu, ok := data.(encoding.TextUnmarshaler); ok {
 			err := tu.UnmarshalText(b)
 			if err != nil {

--- a/text_test.go
+++ b/text_test.go
@@ -43,7 +43,7 @@ func TestTextConsumer(t *testing.T) {
 	assert.Equal(t, consProdText, tu.str)
 
 	// text unmarshal objects can return an error as well, this will be propagated
-	assert.Error(t, cons.Consume(bytes.NewBuffer(nil), &tu))
+	assert.NoError(t, cons.Consume(bytes.NewBuffer(nil), &tu))
 
 	// when readers can't be read, those errors will be propogated as well
 	assert.Error(t, cons.Consume(new(nopReader), &tu))


### PR DESCRIPTION
Short-circuited the unmarshaling in the TextConsumer when response body is empty.