### PR TITLE
Close ByteStreamProducer data implementing ReadCloser

### DIFF
--- a/bytestream.go
+++ b/bytestream.go
@@ -109,6 +109,10 @@ func ByteStreamProducer(opts ...byteStreamOpt) Producer {
 		}
 		defer close()
 
+		if rc, ok := data.(io.ReadCloser); ok {
+			defer rc.Close()
+		}
+
 		if rdr, ok := data.(io.Reader); ok {
 			_, err := io.Copy(writer, rdr)
 			return err

--- a/bytestream_test.go
+++ b/bytestream_test.go
@@ -217,4 +217,14 @@ func TestBytestreamProducer_Close(t *testing.T) {
 		assert.Equal(t, expected, r.String())
 		assert.EqualValues(t, 0, r.calledClose)
 	}
+
+	cons = ByteStreamProducer()
+	r = &closingWriter{}
+	data := &closingReader{b: bytes.NewBufferString(expected)}
+	// can produce using a readcloser
+	if assert.NoError(t, cons.Produce(r, data)) {
+		assert.Equal(t, expected, r.String())
+		assert.EqualValues(t, 0, r.calledClose)
+		assert.EqualValues(t, 1, data.calledClose)
+	}
 }


### PR DESCRIPTION
This commit closes the data when passed into ByteStreamProducer as a
ReadCloser. Example is when go-swagger generates a server handler that
produces "application/octet-stream", the data will be a ReadCloser.

Ref:
- https://github.com/go-openapi/runtime/issues/46
- https://github.com/go-swagger/go-swagger/issues/1311

Signed-off-by: Yongming Lai <yongming.lai@gmail.com>