### PR TITLE
Move AuthenticateRequest call to end of buildHTTP

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -93,12 +93,6 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 		return nil, err
 	}
 
-	if auth != nil {
-		if err := auth.AuthenticateRequest(r, registry); err != nil {
-			return nil, err
-		}
-	}
-
 	// create http request
 	var reinstateSlash bool
 	if r.pathPattern != "" && r.pathPattern != "/" && r.pathPattern[len(r.pathPattern)-1] == '/' {
@@ -241,6 +235,12 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 
 	if runtime.CanHaveBody(req.Method) && req.Body == nil && req.Header.Get(runtime.HeaderContentType) == "" {
 		req.Header.Set(runtime.HeaderContentType, mediaType)
+	}
+
+	if auth != nil {
+		if err := auth.AuthenticateRequest(r, registry); err != nil {
+			return nil, err
+		}
 	}
 
 	return req, nil

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -174,17 +174,19 @@ func TestBuildRequest_BuildHTTP_SetsInAuth(t *testing.T) {
 	bd := []struct{ Name, Hobby string }{{"Tom", "Organ trail"}, {"John", "Bird watching"}}
 	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
 		_ = req.SetBodyParam(bd)
-		_ = req.SetQueryParam("hello", "wrong")
-		_ = req.SetPathParam("id", "wrong")
+		_ = req.SetQueryParam("hello", "world")
+		_ = req.SetPathParam("id", "1234")
 		_ = req.SetHeaderParam("X-Rate-Limit", "wrong")
 		return nil
 	})
 
 	auth := runtime.ClientAuthInfoWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
-		_ = req.SetBodyParam(bd)
-		_ = req.SetQueryParam("hello", "world")
-		_ = req.SetPathParam("id", "1234")
+		_ = req.SetQueryParam("hello", "wrong")
+		_ = req.SetPathParam("id", "wrong")
 		_ = req.SetHeaderParam("X-Rate-Limit", "200")
+		// Make sure the body is accessible to the auth function
+		expectedBody, _ := json.Marshal(bd)
+		assert.Equal(t, append(expectedBody, '\n'), req.GetBody())
 		return nil
 	})
 

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -348,11 +348,6 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 	if auth == nil && r.DefaultAuthentication != nil {
 		auth = r.DefaultAuthentication
 	}
-	//if auth != nil {
-	//	if err := auth.AuthenticateRequest(request, r.Formats); err != nil {
-	//		return nil, err
-	//	}
-	//}
 
 	// TODO: pick appropriate media type
 	cmt := r.DefaultMediaType


### PR DESCRIPTION

Move the AuthenticateRequest call in buildHTTP() to be at the end and after the body is available to the ClientRequest.  This way anyone that wants to do any signing based on the body of the request will have access to it.

Fixes: https://github.com/go-openapi/runtime/issues/153

Signed-off-by: Keith Holleman <keithh@cisco.com>