### PR TITLE
Fixing issue where context modifications in authenticators are ignored

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -433,6 +433,8 @@ func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interfa
 		}
 	}
 
+	rCtx = request.Context()
+
 	rCtx = stdContext.WithValue(rCtx, ctxSecurityPrincipal, usr)
 	rCtx = stdContext.WithValue(rCtx, ctxSecurityScopes, route.Authenticator.AllScopes())
 	return usr, request.WithContext(rCtx), nil


### PR DESCRIPTION
This PR address the issue where if the Authenticator adds new http.Request contexts the current it is retained downstream.

Signed-off-by: Rob Rodriguez <rob@modelrocket.io>