### PR TITLE
different envs

### DIFF
--- a/client/runtime_test.go
+++ b/client/runtime_test.go
@@ -869,6 +869,10 @@ func TestRuntime_DebugValue(t *testing.T) {
 	runtime = New("", "/", []string{"https"})
 	assert.True(t, runtime.Debug)
 
+	_ = os.Setenv("DEBUG", "false")
+	runtime = New("", "/", []string{"https"})
+	assert.False(t, runtime.Debug)
+
 	_ = os.Setenv("DEBUG", "foo")
 	runtime = New("", "/", []string{"https"})
 	assert.True(t, runtime.Debug)

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -9,12 +9,12 @@ type Logger interface {
 
 func DebugEnabled() bool {
 	d := os.Getenv("SWAGGER_DEBUG")
-	if d == "" || d == "false" || d == "0" {
-		return false
+	if d != "" && d != "false" && d != "0" {
+		return true
 	}
 	d = os.Getenv("DEBUG")
-	if d == "" || d == "false" || d == "0" {
-		return false
+	if d != "" && d != "false" && d != "0" {
+		return true
 	}
-	return true
+	return false
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,5 +8,13 @@ type Logger interface {
 }
 
 func DebugEnabled() bool {
-	return os.Getenv("SWAGGER_DEBUG") != "" || os.Getenv("DEBUG") != ""
+	d := os.Getenv("SWAGGER_DEBUG")
+	if d == "" || d == "false" || d == "0" {
+		return false
+	}
+	d = os.Getenv("DEBUG")
+	if d == "" || d == "false" || d == "0" {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
Current way of checking the debug flag may affect many current applications where DEBUG flag is specified more precisely. Let's avoid it.