### PR TITLE
Colon must be at beginning of path segment to denote a path parameter

### DIFF
--- a/middleware/denco/router.go
+++ b/middleware/denco/router.go
@@ -17,6 +17,9 @@ const (
 	// TerminationCharacter is a special character for end of path.
 	TerminationCharacter = '#'
 
+	// SeparatorCharacter separates path segments.
+	SeparatorCharacter = '/'
+
 	// MaxSize is max size of records and internal slice.
 	MaxSize = (1 << 22) - 1
 )
@@ -420,10 +423,11 @@ type record struct {
 
 // makeRecords returns the records that use to build Double-Arrays.
 func makeRecords(srcs []Record) (statics, params []*record) {
-	spChars := string([]byte{ParamCharacter, WildcardCharacter})
 	termChar := string(TerminationCharacter)
+	paramPrefix := string(SeparatorCharacter) + string(ParamCharacter)
+	wildcardPrefix :=  string(SeparatorCharacter) + string(WildcardCharacter)
 	for _, r := range srcs {
-		if strings.ContainsAny(r.Key, spChars) {
+		if strings.Contains(r.Key, paramPrefix) || strings.Contains(r.Key, wildcardPrefix) {
 			r.Key += termChar
 			params = append(params, &record{Record: r})
 		} else {

--- a/middleware/denco/router_test.go
+++ b/middleware/denco/router_test.go
@@ -448,6 +448,7 @@ func TestRouter_Build_withoutSizeHint(t *testing.T) {
 		{[]string{"/user"}, 0},
 		{[]string{"/user/:id"}, 1},
 		{[]string{"/user/:id/post"}, 1},
+		{[]string{"/user/:id/post:validate"}, 2},
 		{[]string{"/user/:id/:group"}, 2},
 		{[]string{"/user/:id/post/:cid"}, 2},
 		{[]string{"/user/:id/post/:cid", "/admin/:id/post/:cid"}, 2},
@@ -487,6 +488,7 @@ func TestRouter_Build_withSizeHint(t *testing.T) {
 		{"/user/:id", 3, 3},
 		{"/user/:id/:group", 0, 0},
 		{"/user/:id/:group", 1, 1},
+		{"/user/:id/:group:validate", 1, 1},
 	} {
 		r := denco.New()
 		r.SizeHint = v.sizeHint


### PR DESCRIPTION
Signed-off-by: Sean Prince <7532924+seanprince@users.noreply.github.com>

Tightened route parsing to treat colons appearing as the first character of a path segment as path parameters. Colons appearing elsewhere in the path segment are treated as a static path segment. 

This PR fixes https://github.com/go-openapi/runtime/issues/162
