### PR TITLE
Bugfix: Handle Accept header not provided

### DIFF
--- a/fixtures/bugs/174/swagger.yml
+++ b/fixtures/bugs/174/swagger.yml
@@ -4,8 +4,6 @@ info:
   title: 'Test'
 schemes:
   - http
-produces:
-  - application/vnd.cia.v1+json
 
 paths:
   /pets:
@@ -43,7 +41,9 @@ paths:
       description: Creates a new pet in the store.  Duplicates are allowed
       operationId: addPet
       consumes:
-        - application/vnd.cia.v1+json
+        - application/json
+      produces:
+        - application/json
       parameters:
         - name: pet
           in: body

--- a/middleware/context.go
+++ b/middleware/context.go
@@ -305,6 +305,12 @@ func (c *Context) BindValidRequest(request *http.Request, route *MatchedRoute, b
 
 	// check and validate the response format
 	if len(res) == 0 {
+		// if the route does not provide Produces and a default contentType could not be identified
+		// based on a body, typical for GET and DELETE requests, then default contentType to.
+		if len(route.Produces) == 0 && requestContentType == "" {
+			requestContentType = "*/*"
+		}
+
 		if str := NegotiateContentType(request, route.Produces, requestContentType); str == "" {
 			res = append(res, errors.InvalidResponseFormat(request.Header.Get(runtime.HeaderAccept), route.Produces))
 		}

--- a/middleware/validation.go
+++ b/middleware/validation.go
@@ -116,7 +116,10 @@ func (v *validation) contentType() {
 }
 
 func (v *validation) responseFormat() {
-	if str, rCtx := v.context.ResponseFormat(v.request, v.route.Produces); str == "" {
+	// if the route provides values for Produces and no format could be identify then return an error.
+	// if the route does not specify values for Produces then treat request as valid since the API designer
+	// choose not to specify the format for responses.
+	if str, rCtx := v.context.ResponseFormat(v.request, v.route.Produces); str == "" && len(v.route.Produces) > 0 {
 		v.request = rCtx
 		v.result = append(v.result, errors.InvalidResponseFormat(v.request.Header.Get(runtime.HeaderAccept), v.route.Produces))
 	}


### PR DESCRIPTION
As part of #172, the Accept header validation was being enforced.
This resulted in a backwards-compatibility issues where if Accept
header was not provided, it would result in an error.
When an Accept header is not provided the client is indicating it
will accept the default response format. As such it should not result
in an error.

Applies fix to provide a default value when no default could be
identified from the request body or using the defined produces on the
specific route.

Applies fix to validation to consider the request valid if no format
could be identified using just the request and produces is empty.

resolves: #174
Signed-off-by: kenjones <kenjones@cisco.com>