### PR TITLE
Expose UntypedRequestBinder so that others can use it.

### DIFF
--- a/middleware/request.go
+++ b/middleware/request.go
@@ -25,21 +25,21 @@ import (
 	"github.com/go-openapi/runtime"
 )
 
-// RequestBinder binds and validates the data from a http request
-type untypedRequestBinder struct {
+// UntypedRequestBinder binds and validates the data from a http request
+type UntypedRequestBinder struct {
 	Spec         *spec.Swagger
 	Parameters   map[string]spec.Parameter
 	Formats      strfmt.Registry
 	paramBinders map[string]*untypedParamBinder
 }
 
-// NewRequestBinder creates a new binder for reading a request.
-func newUntypedRequestBinder(parameters map[string]spec.Parameter, spec *spec.Swagger, formats strfmt.Registry) *untypedRequestBinder {
+// NewUntypedRequestBinder creates a new binder for reading a request.
+func NewUntypedRequestBinder(parameters map[string]spec.Parameter, spec *spec.Swagger, formats strfmt.Registry) *UntypedRequestBinder {
 	binders := make(map[string]*untypedParamBinder)
 	for fieldName, param := range parameters {
 		binders[fieldName] = newUntypedParamBinder(param, spec, formats)
 	}
-	return &untypedRequestBinder{
+	return &UntypedRequestBinder{
 		Parameters:   parameters,
 		paramBinders: binders,
 		Spec:         spec,
@@ -48,7 +48,7 @@ func newUntypedRequestBinder(parameters map[string]spec.Parameter, spec *spec.Sw
 }
 
 // Bind perform the databinding and validation
-func (o *untypedRequestBinder) Bind(request *http.Request, routeParams RouteParams, consumer runtime.Consumer, data interface{}) error {
+func (o *UntypedRequestBinder) Bind(request *http.Request, routeParams RouteParams, consumer runtime.Consumer, data interface{}) error {
 	val := reflect.Indirect(reflect.ValueOf(data))
 	isMap := val.Kind() == reflect.Map
 	var result []error

--- a/middleware/request_test.go
+++ b/middleware/request_test.go
@@ -200,7 +200,7 @@ func TestRequestBindingDefaultValue(t *testing.T) {
 
 	req, _ := http.NewRequest("POST", uri.String(), bytes.NewBuffer(nil))
 	req.Header.Set("Content-Type", "application/json")
-	binder := newUntypedRequestBinder(op3, new(spec.Swagger), strfmt.Default)
+	binder := NewUntypedRequestBinder(op3, new(spec.Swagger), strfmt.Default)
 
 	data := make(map[string]interface{})
 	err := binder.Bind(req, RouteParams(nil), runtime.JSONConsumer(), &data)
@@ -224,14 +224,14 @@ func TestRequestBindingForInvalid(t *testing.T) {
 
 	op1 := map[string]spec.Parameter{"Some": *invalidParam}
 
-	binder := newUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
+	binder := NewUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
 	req, _ := http.NewRequest("GET", "http://localhost:8002/hello?name=the-name", nil)
 
 	err := binder.Bind(req, nil, new(stubConsumer), new(jsonRequestParams))
 	assert.Error(t, err)
 
 	op2 := parametersForJSONRequestParams("")
-	binder = newUntypedRequestBinder(op2, new(spec.Swagger), strfmt.Default)
+	binder = NewUntypedRequestBinder(op2, new(spec.Swagger), strfmt.Default)
 
 	req, _ = http.NewRequest("POST", "http://localhost:8002/hello/1?name=the-name", bytes.NewBuffer([]byte(`{"name":"toby","age":32}`)))
 	req.Header.Set("Content-Type", "application(")
@@ -247,7 +247,7 @@ func TestRequestBindingForInvalid(t *testing.T) {
 
 	invalidMultiParam := spec.HeaderParam("tags").CollectionOf(new(spec.Items), "multi")
 	op3 := map[string]spec.Parameter{"Tags": *invalidMultiParam}
-	binder = newUntypedRequestBinder(op3, new(spec.Swagger), strfmt.Default)
+	binder = NewUntypedRequestBinder(op3, new(spec.Swagger), strfmt.Default)
 
 	req, _ = http.NewRequest("POST", "http://localhost:8002/hello/1?name=the-name", bytes.NewBuffer([]byte(`{}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -258,7 +258,7 @@ func TestRequestBindingForInvalid(t *testing.T) {
 	invalidMultiParam = spec.PathParam("").CollectionOf(new(spec.Items), "multi")
 
 	op4 := map[string]spec.Parameter{"Tags": *invalidMultiParam}
-	binder = newUntypedRequestBinder(op4, new(spec.Swagger), strfmt.Default)
+	binder = NewUntypedRequestBinder(op4, new(spec.Swagger), strfmt.Default)
 
 	req, _ = http.NewRequest("POST", "http://localhost:8002/hello/1?name=the-name", bytes.NewBuffer([]byte(`{}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -269,7 +269,7 @@ func TestRequestBindingForInvalid(t *testing.T) {
 	invalidInParam := spec.HeaderParam("tags").Typed("string", "")
 	invalidInParam.In = "invalid"
 	op5 := map[string]spec.Parameter{"Tags": *invalidInParam}
-	binder = newUntypedRequestBinder(op5, new(spec.Swagger), strfmt.Default)
+	binder = NewUntypedRequestBinder(op5, new(spec.Swagger), strfmt.Default)
 
 	req, _ = http.NewRequest("POST", "http://localhost:8002/hello/1?name=the-name", bytes.NewBuffer([]byte(`{}`)))
 	req.Header.Set("Content-Type", "application/json")
@@ -282,7 +282,7 @@ func TestRequestBindingForValid(t *testing.T) {
 	for _, fmt := range []string{"csv", "pipes", "tsv", "ssv", "multi"} {
 		op1 := parametersForJSONRequestParams(fmt)
 
-		binder := newUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
+		binder := NewUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
 
 		lval := []string{"one", "two", "three"}
 		var queryString string
@@ -327,7 +327,7 @@ func TestRequestBindingForValid(t *testing.T) {
 
 	op1 := parametersForJSONRequestParams("")
 
-	binder := newUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
+	binder := NewUntypedRequestBinder(op1, new(spec.Swagger), strfmt.Default)
 	urlStr := "http://localhost:8002/hello/1?name=the-name&tags=one,two,three"
 	req, _ := http.NewRequest("POST", urlStr, bytes.NewBuffer([]byte(`{"name":"toby","age":32}`)))
 	req.Header.Set("Content-Type", "application/json;charset=utf-8")
@@ -351,7 +351,7 @@ func TestRequestBindingForValid(t *testing.T) {
 	req.Header.Set("Content-Type", "application/json;charset=utf-8")
 	req.Header.Set("X-Request-Id", "1325959595")
 	op2 := parametersForJSONRequestSliceParams("")
-	binder = newUntypedRequestBinder(op2, new(spec.Swagger), strfmt.Default)
+	binder = NewUntypedRequestBinder(op2, new(spec.Swagger), strfmt.Default)
 	data3 := jsonRequestSlice{}
 	err = binder.Bind(req, []RouteParam{{"id", "1"}}, runtime.JSONConsumer(), &data3)
 
@@ -379,7 +379,7 @@ func parametersForFormUpload() map[string]spec.Parameter {
 
 func TestFormUpload(t *testing.T) {
 	params := parametersForFormUpload()
-	binder := newUntypedRequestBinder(params, new(spec.Swagger), strfmt.Default)
+	binder := NewUntypedRequestBinder(params, new(spec.Swagger), strfmt.Default)
 
 	urlStr := "http://localhost:8002/hello"
 	req, _ := http.NewRequest("POST", urlStr, bytes.NewBufferString(`name=the-name&age=32`))
@@ -403,13 +403,13 @@ type fileRequest struct {
 	File runtime.File // upload
 }
 
-func paramsForFileUpload() *untypedRequestBinder {
+func paramsForFileUpload() *UntypedRequestBinder {
 	nameParam := spec.FormDataParam("name").Typed("string", "")
 
 	fileParam := spec.FileParam("file")
 
 	params := map[string]spec.Parameter{"Name": *nameParam, "File": *fileParam}
-	return newUntypedRequestBinder(params, new(spec.Swagger), strfmt.Default)
+	return NewUntypedRequestBinder(params, new(spec.Swagger), strfmt.Default)
 }
 
 func TestBindingFileUpload(t *testing.T) {

--- a/middleware/router.go
+++ b/middleware/router.go
@@ -291,7 +291,7 @@ type routeEntry struct {
 	Parameters     map[string]spec.Parameter
 	Handler        http.Handler
 	Formats        strfmt.Registry
-	Binder         *untypedRequestBinder
+	Binder         *UntypedRequestBinder
 	Authenticators RouteAuthenticators
 	Authorizer     runtime.Authorizer
 }
@@ -429,7 +429,7 @@ func (d *defaultRouteBuilder) AddRoute(method, path string, operation *spec.Oper
 			Producers:      d.api.ProducersFor(normalizeOffers(produces)),
 			Parameters:     parameters,
 			Formats:        d.api.Formats(),
-			Binder:         newUntypedRequestBinder(parameters, d.spec.Spec(), d.api.Formats()),
+			Binder:         NewUntypedRequestBinder(parameters, d.spec.Spec(), d.api.Formats()),
 			Authenticators: d.buildAuthenticators(operation),
 			Authorizer:     d.api.Authorizer(),
 		})

--- a/middleware/untyped_request_test.go
+++ b/middleware/untyped_request_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestUntypedFormPost(t *testing.T) {
 	params := parametersForFormUpload()
-	binder := newUntypedRequestBinder(params, nil, strfmt.Default)
+	binder := NewUntypedRequestBinder(params, nil, strfmt.Default)
 
 	urlStr := "http://localhost:8002/hello"
 	req, _ := http.NewRequest("POST", urlStr, bytes.NewBufferString(`name=the-name&age=32`))
@@ -115,7 +115,7 @@ func TestUntypedFileUpload(t *testing.T) {
 
 func TestUntypedBindingTypesForValid(t *testing.T) {
 	op2 := parametersForAllTypes("")
-	binder := newUntypedRequestBinder(op2, nil, strfmt.Default)
+	binder := NewUntypedRequestBinder(op2, nil, strfmt.Default)
 
 	confirmed := true
 	name := "thomas"


### PR DESCRIPTION
As discussed [on slack][slack], this change converts `untypedRequestBinder` to `UntypedRequestBinder`, and it's construction function `newUntypedRequestBinder` to `NewUntypedRequestBinder`, so that they can both be imported by other packages.

[slack]: https://gophers.slack.com/archives/C0CLYLPCM/p1585174622002500