### PR TITLE
Retain error after authorization

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -435,6 +435,9 @@ func (c *Context) Authorize(request *http.Request, route *MatchedRoute) (interfa
 	}
 	if route.Authorizer != nil {
 		if err := route.Authorizer.Authorize(request, usr); err != nil {
+			if _, ok := err.(errors.Error) ; ok {
+				return nil, nil, err
+			}
 			return nil, nil, errors.New(http.StatusForbidden, err.Error())
 		}
 	}


### PR DESCRIPTION
Authorization can return internal error or any other type of error that doesn't mean that the user is not authorized, like 500, 503 etc.

Signed-off-by: Michael Filanov <mfilanov@redhat.com>