### PR TITLE
Add producer and consumer for YAML

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -36,6 +36,7 @@ import (
 	"github.com/go-openapi/runtime"
 	"github.com/go-openapi/runtime/logger"
 	"github.com/go-openapi/runtime/middleware"
+	"github.com/go-openapi/runtime/yamlpc"
 )
 
 // TLSClientOptions to configure client authentication with mutual TLS
@@ -244,6 +245,7 @@ func New(host, basePath string, schemes []string) *Runtime {
 
 	// TODO: actually infer this stuff from the spec
 	rt.Consumers = map[string]runtime.Consumer{
+		runtime.YAMLMime:    yamlpc.YAMLConsumer(),
 		runtime.JSONMime:    runtime.JSONConsumer(),
 		runtime.XMLMime:     runtime.XMLConsumer(),
 		runtime.TextMime:    runtime.TextConsumer(),
@@ -252,6 +254,7 @@ func New(host, basePath string, schemes []string) *Runtime {
 		runtime.DefaultMime: runtime.ByteStreamConsumer(),
 	}
 	rt.Producers = map[string]runtime.Producer{
+		runtime.YAMLMime:    yamlpc.YAMLProducer(),
 		runtime.JSONMime:    runtime.JSONProducer(),
 		runtime.XMLMime:     runtime.XMLProducer(),
 		runtime.TextMime:    runtime.TextProducer(),

--- a/yamlpc/yaml.go
+++ b/yamlpc/yaml.go
@@ -16,7 +16,6 @@ package yamlpc
 
 import (
 	"io"
-	"io/ioutil"
 
 	"github.com/go-openapi/runtime"
 
@@ -26,19 +25,16 @@ import (
 // YAMLConsumer creates a consumer for yaml data
 func YAMLConsumer() runtime.Consumer {
 	return runtime.ConsumerFunc(func(r io.Reader, v interface{}) error {
-		buf, err := ioutil.ReadAll(r)
-		if err != nil {
-			return err
-		}
-		return yaml.Unmarshal(buf, v)
+		dec := yaml.NewDecoder(r)
+		return dec.Decode(v)
 	})
 }
 
 // YAMLProducer creates a producer for yaml data
 func YAMLProducer() runtime.Producer {
 	return runtime.ProducerFunc(func(w io.Writer, v interface{}) error {
-		b, _ := yaml.Marshal(v) // can't make this error come up
-		_, err := w.Write(b)
-		return err
+		enc := yaml.NewEncoder(w)
+		defer enc.Close()
+		return enc.Encode(v)
 	})
 }

--- a/yamlpc/yaml_test.go
+++ b/yamlpc/yaml_test.go
@@ -50,13 +50,23 @@ func TestYAMLProducer(t *testing.T) {
 	assert.Equal(t, consProdYAML, rw.Body.String())
 }
 
-type failReader struct {
+type failReaderWriter struct {
 }
 
-func (f *failReader) Read(p []byte) (n int, err error) {
+func (f *failReaderWriter) Read(p []byte) (n int, err error) {
 	return 0, errors.New("expected")
 }
+
+func (f *failReaderWriter) Write(p []byte) (n int, err error) {
+	return 0, errors.New("expected")
+}
+
+func TestFailYAMLWriter(t *testing.T) {
+	prod := YAMLProducer()
+	assert.Error(t, prod.Produce(&failReaderWriter{}, nil))
+}
+
 func TestFailYAMLReader(t *testing.T) {
 	cons := YAMLConsumer()
-	assert.Error(t, cons.Consume(&failReader{}, nil))
+	assert.Error(t, cons.Consume(&failReaderWriter{}, nil))
 }


### PR DESCRIPTION
This PR does the following:
1. Adds the producer and consumer for YAML. I realise that there is a plan to infer these instead of having hard-coded defaults. But for the time-being adding the producer and consumer for YAML as a default is very convenient, and doesn't do any harm. Especially since the Producer and Consumer are already written for YAML in the codebase.
2. Uses `yaml.NewDecoder(r)` instead of `ioutil.ReadAll(r)` as it includes its own buffering.
3. Adds YAML Writer fail test case.