### PR TITLE
fix InsecureSkipVerify comment

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -82,7 +82,7 @@ type TLSClientOptions struct {
 	ServerName string
 
 	// InsecureSkipVerify controls whether the certificate chain and hostname presented
-	// by the server are validated. If false, any certificate is accepted.
+	// by the server are validated. If true, any certificate is accepted.
 	InsecureSkipVerify bool
 
 	// VerifyPeerCertificate, if not nil, is called after normal


### PR DESCRIPTION
From some experiment with runtime client and a server exposing self-signed certificate, it's actually skipping certificate checking when true (also makes more sense with the field name, `InsecureSkipVerify`)