### PR TITLE
When response body is binary, DEBUG mode should not print it

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -450,17 +450,21 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 	}
 	defer res.Body.Close()
 
+	ct := res.Header.Get(runtime.HeaderContentType)
+	if ct == "" { // this should really really never occur
+		ct = r.DefaultMediaType
+	}
+
 	if r.Debug {
-		b, err2 := httputil.DumpResponse(res, true)
+		printBody := true
+		if ct == runtime.DefaultMime {
+			printBody = false // Spare the terminal from a binary blob.
+		}
+		b, err2 := httputil.DumpResponse(res, printBody)
 		if err2 != nil {
 			return nil, err2
 		}
 		r.logger.Debugf("%s\n", string(b))
-	}
-
-	ct := res.Header.Get(runtime.HeaderContentType)
-	if ct == "" { // this should really really never occur
-		ct = r.DefaultMediaType
 	}
 
 	mt, _, err := mime.ParseMediaType(ct)


### PR DESCRIPTION
When the response is a binary blob, printing it can mess up the
user's terminal. This change checks the response type and, if
the response is an octet-stream, omits the response body from
the logs.

Note that octet-stream is not the default response body type, so
it is unlikely that we will falsely omit a response body which
was not actually binary.

Signed-off-by: andrew2nelson <andrew2nelson@arista.com>