### PR TITLE
route creation: append API default consumer and producer if not explicitly part of the analyzed spec

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -39,3 +39,4 @@ linters:
     - nestif
     - godot
     - errorlint
+    - noctx

--- a/middleware/context_test.go
+++ b/middleware/context_test.go
@@ -93,10 +93,16 @@ func TestContentType_Issue172(t *testing.T) {
 
 		handler := Serve(swspec, api)
 		request, _ := http.NewRequest("GET", "/pets", nil)
-		request.Header.Add("Accept", "application/json")
+		request.Header.Add("Accept", "application/json+special")
 		recorder := httptest.NewRecorder()
 		handler.ServeHTTP(recorder, request)
 		assert.Equal(t, http.StatusNotAcceptable, recorder.Code)
+
+		// acceptable as defined as default by the API (not explicit in the spec)
+		request.Header.Add("Accept", "application/json")
+		recorder = httptest.NewRecorder()
+		handler.ServeHTTP(recorder, request)
+		assert.Equal(t, http.StatusOK, recorder.Code)
 	}
 }
 

--- a/middleware/router.go
+++ b/middleware/router.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/go-openapi/runtime/security"
+	"github.com/go-openapi/swag"
 
 	"github.com/go-openapi/analysis"
 	"github.com/go-openapi/errors"
@@ -417,6 +418,15 @@ func (d *defaultRouteBuilder) AddRoute(method, path string, operation *spec.Oper
 		consumes := d.analyzer.ConsumesFor(operation)
 		produces := d.analyzer.ProducesFor(operation)
 		parameters := d.analyzer.ParamsFor(method, strings.TrimPrefix(path, bp))
+
+		// add API defaults if not part of the spec
+		if defConsumes := d.api.DefaultConsumes(); defConsumes != "" && !swag.ContainsStringsCI(consumes, defConsumes) {
+			consumes = append(consumes, defConsumes)
+		}
+
+		if defProduces := d.api.DefaultProduces(); defProduces != "" && !swag.ContainsStringsCI(produces, defProduces) {
+			produces = append(produces, defProduces)
+		}
 
 		record := denco.NewRecord(pathConverter.ReplaceAllString(path, ":$1"), &routeEntry{
 			BasePath:       bp,

--- a/middleware/router_test.go
+++ b/middleware/router_test.go
@@ -119,10 +119,15 @@ func TestRouterBuilder(t *testing.T) {
 	rec := postRecords[0]
 	assert.Equal(t, rec.Key, "/pets")
 	val := rec.Value.(*routeEntry)
-	assert.Len(t, val.Consumers, 1)
-	assert.Len(t, val.Producers, 1)
-	assert.Len(t, val.Consumes, 1)
-	assert.Len(t, val.Produces, 1)
+	assert.Len(t, val.Consumers, 2)
+	assert.Len(t, val.Producers, 2)
+	assert.Len(t, val.Consumes, 2)
+	assert.Len(t, val.Produces, 2)
+
+	assert.Contains(t, val.Consumers, "application/json")
+	assert.Contains(t, val.Producers, "application/x-yaml")
+	assert.Contains(t, val.Consumes, "application/json")
+	assert.Contains(t, val.Produces, "application/x-yaml")
 
 	assert.Len(t, val.Parameters, 1)
 


### PR DESCRIPTION


Whenever the spec is not explicit about some consumers or producers, the API publishes some internal default (e.g. application/json).
However, the lists registered for the route are not updated accordingly.

* contributes go-swagger/go-swagger#1430

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>