### PR TITLE
add AuthInfoWriter Composition

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.go text eol=lf

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,25 @@
+name: Go
+
+on:
+  push:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: 1.16.2
+
+    - name: Setup gotestsum
+      uses: autero1/action-gotestsum@v0.1.0
+      with:
+        gotestsum_version: 1.6.2
+
+    - name: Test
+      run: gotestsum --format short-verbose -- -race -timeout=20m -coverprofile=coverage.txt -covermode=atomic ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 after_success:
 - bash <(curl -s https://codecov.io/bash)
 go:
-- 1.14.x
 - 1.x
 install:
 - GO111MODULE=off go get -u gotest.tools/gotestsum

--- a/client/auth_info.go
+++ b/client/auth_info.go
@@ -59,3 +59,19 @@ func BearerToken(token string) runtime.ClientAuthInfoWriter {
 		return r.SetHeaderParam("Authorization", "Bearer "+token)
 	})
 }
+
+// Compose combines multiple ClientAuthInfoWriters into a single one.
+// Useful when multiple auth headers are needed.
+func Compose(auths ...runtime.ClientAuthInfoWriter) runtime.ClientAuthInfoWriter {
+	return runtime.ClientAuthInfoWriterFunc(func(r runtime.ClientRequest, _ strfmt.Registry) error {
+		for _, auth := range auths {
+			if auth == nil {
+				continue
+			}
+			if err := auth.AuthenticateRequest(r, nil); err != nil {
+				return err
+			}
+		}
+		return nil
+	})
+}

--- a/client/auth_info_test.go
+++ b/client/auth_info_test.go
@@ -67,3 +67,14 @@ func TestBearerTokenAuth(t *testing.T) {
 
 	assert.Equal(t, "Bearer the-shared-token", r.header.Get("Authorization"))
 }
+
+func TestCompose(t *testing.T) {
+	r, _ := newRequest("GET", "/", nil)
+
+	writer := Compose(APIKeyAuth("x-api-key", "header", "the-api-key"), APIKeyAuth("x-secret-key", "header", "the-secret-key"))
+	err := writer.AuthenticateRequest(r, nil)
+	assert.NoError(t, err)
+
+	assert.Equal(t, "the-api-key", r.header.Get("x-api-key"))
+	assert.Equal(t, "the-secret-key", r.header.Get("x-secret-key"))
+}


### PR DESCRIPTION
Signed-off-by: Youyuan Wu <youyuanwu@outlook.com>

Support AuthInfoWriter composition. When multiple api key headers needed, the new function is useful. One can also combine basic auth and api-key.