### PR TITLE
Add handling for Accept header q=./d

### DIFF
--- a/middleware/header/header.go
+++ b/middleware/header/header.go
@@ -265,13 +265,16 @@ func expectQuality(s string) (q float64, rest string) {
 	case len(s) == 0:
 		return -1, ""
 	case s[0] == '0':
-		q = 0
+		// q is already 0
+		s = s[1:]
 	case s[0] == '1':
+		s = s[1:]
 		q = 1
+	case s[0] == '.':
+		// q is already 0
 	default:
 		return -1, ""
 	}
-	s = s[1:]
 	if !strings.HasPrefix(s, ".") {
 		return q, s
 	}

--- a/middleware/negotiate_test.go
+++ b/middleware/negotiate_test.go
@@ -62,6 +62,8 @@ var negotiateContentTypeTests = []struct {
 	{"application/json", []string{"application/json; charset=utf-8", "image/png"}, "", "application/json; charset=utf-8"},
 	{"application/json; charset=utf-8", []string{"application/json; charset=utf-8", "image/png"}, "", "application/json; charset=utf-8"},
 	{"application/json", []string{"application/vnd.cia.v1+json"}, "", ""},
+	// Default header of java clients
+	{"text/html, image/gif, image/jpeg, *; q=.2, */*; q=.2", []string{"application/json"}, "", "application/json"},
 }
 
 func TestNegotiateContentType(t *testing.T) {


### PR DESCRIPTION
It is not consistent with RFC 7231 but it is present in default value for Accept header in Java clients

Signed-off-by: Tomasz Swider <tomaszswider4@gmail.com>