### PR TITLE
Allows base paths to include query parameters

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -308,7 +308,7 @@ DoneChoosingBodySource:
 	for k, v := range basePathQueryParams {
 		_, present := originalParams[k]
 		if !present {
-			r.SetQueryParam(k, v...)
+			_ = r.SetQueryParam(k, v...)
 		}
 	}
 

--- a/client/request.go
+++ b/client/request.go
@@ -279,6 +279,7 @@ DoneChoosingBodySource:
 		reinstateSlash = true
 	}
 
+	// In case the basePath includes hardcoded query parameters, parse those out
 	basePathURL, err := url.Parse(basePath)
 	if err != nil {
 		return nil, err
@@ -300,6 +301,8 @@ DoneChoosingBodySource:
 
 	originalParams := r.GetQueryParams()
 
+	// Merge the query parameters extracted from the basePath with the ones set by
+	// the client in this struct. In case of conflict, the client wins.
 	for k, v := range basePathQueryParams {
 		_, present := originalParams[k]
 		if !present {

--- a/client/request.go
+++ b/client/request.go
@@ -279,7 +279,9 @@ DoneChoosingBodySource:
 		reinstateSlash = true
 	}
 
-	// In case the basePath includes hardcoded query parameters, parse those out
+	// In case the basePath includes hardcoded query parameters, parse those out before
+	// constructing the final path. The parameters themselves will be merged with the
+	// ones set by the client, with the priority given to the latter.
 	basePathURL, err := url.Parse(basePath)
 	if err != nil {
 		return nil, err

--- a/client/request.go
+++ b/client/request.go
@@ -308,7 +308,9 @@ DoneChoosingBodySource:
 	for k, v := range basePathQueryParams {
 		_, present := originalParams[k]
 		if !present {
-			_ = r.SetQueryParam(k, v...)
+			if err = r.SetQueryParam(k, v...); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -517,6 +517,39 @@ func TestBuildRequest_BuildHTTP_EscapedPath(t *testing.T) {
 	}
 }
 
+func TestBuildRequest_BuildHTTP_BasePathWithParameters(t *testing.T) {
+	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+		_ = req.SetBodyParam(nil)
+		_ = req.SetQueryParam("hello", "world")
+		_ = req.SetPathParam("id", "1234")
+		return nil
+	})
+	r, _ := newRequest("POST", "/flats/{id}/", reqWrtr)
+
+	req, err := r.BuildHTTP(runtime.JSONMime, "/basepath?foo=bar", testProducers, nil)
+	if assert.NoError(t, err) && assert.NotNil(t, req) {
+		assert.Equal(t, "world", req.URL.Query().Get("hello"))
+		assert.Equal(t, "bar", req.URL.Query().Get("foo"))
+		assert.Equal(t, "/basepath/flats/1234/", req.URL.Path)
+	}
+}
+
+func TestBuildRequest_BuildHTTP_BasePathWithConflictingParameters(t *testing.T) {
+	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
+		_ = req.SetBodyParam(nil)
+		_ = req.SetQueryParam("hello", "world")
+		_ = req.SetPathParam("id", "1234")
+		return nil
+	})
+	r, _ := newRequest("POST", "/flats/{id}/", reqWrtr)
+
+	req, err := r.BuildHTTP(runtime.JSONMime, "/basepath?hello=kitty", testProducers, nil)
+	if assert.NoError(t, err) && assert.NotNil(t, req) {
+		assert.Equal(t, "world", req.URL.Query().Get("hello"))
+		assert.Equal(t, "/basepath/flats/1234/", req.URL.Path)
+	}
+}
+
 type testReqFn func(*testing.T, *http.Request)
 
 type testRoundTripper struct {


### PR DESCRIPTION
This is a test case and a fix for https://github.com/go-openapi/runtime/issues/207.

When the base path of an operation contains a query string, those parameters are:

1. extracted before appending any path parameters to the path
2. merged with the query parameters passed by the client

In the case of a conflict between the parameters passed in the API call and the ones declared in the base path, the former prevails. This gives end control to clients.