### PR TITLE
Stop preparing the request if an error occurs

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -139,6 +139,7 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 					if err := mp.WriteField(fn, vi); err != nil {
 						pw.CloseWithError(err)
 						log.Println(err)
+						return
 					}
 				}
 			}
@@ -158,6 +159,7 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 					if err != nil {
 						_ = pw.CloseWithError(err)
 						log.Println(err)
+						return
 					}
 					fileContentType := http.DetectContentType(buf)
 					newFi := runtime.NamedReader(fi.Name(), io.MultiReader(bytes.NewReader(buf[:size]), fi))
@@ -173,7 +175,9 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 					if err != nil {
 						pw.CloseWithError(err)
 						log.Println(err)
-					} else if _, err := io.Copy(wrtr, newFi); err != nil {
+						return
+					}
+					if _, err := io.Copy(wrtr, newFi); err != nil {
 						pw.CloseWithError(err)
 						log.Println(err)
 					}


### PR DESCRIPTION
`request.buildHTTP` closes the writer but keeps preparing the request if an error occurs. Since the writer is already closed, other following write operations also fail. This PR changes this behaviour so that the function returns earlier and stops the preparation.

This PR fixes #215.