### PR TITLE
Run all tests in all platforms even one of them fails

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
+      fail-fast: false
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Currently tests are failing on Windows but it shouldn't stop the tests
on Linux and macOS.

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>