### PR TITLE
feat: add pathParamEscaped support

### DIFF
--- a/bytestream_test.go
+++ b/bytestream_test.go
@@ -25,7 +25,7 @@ func TestByteStreamConsumer(t *testing.T) {
 	var s string
 	if assert.NoError(t, cons.Consume(bytes.NewBufferString(expected), &s)) {
 		assert.Equal(t, expected, s)
-	}	
+	}
 
 	// can consume as an UnmarshalBinary
 	var bu binaryUnmarshalDummy

--- a/client_request.go
+++ b/client_request.go
@@ -50,7 +50,7 @@ type ClientRequest interface {
 
 	SetPathParam(string, string) error
 
-	SetPathParamEscaped(name string, escape bool) error
+	SetPathParamEscaped(string, bool) error
 
 	GetQueryParams() url.Values
 
@@ -123,7 +123,7 @@ func (t *TestClientRequest) SetFormParam(_ string, _ ...string) error { return n
 
 func (t *TestClientRequest) SetPathParam(_ string, _ string) error { return nil }
 
-func (t *TestClientRequest) SetPathParamEscaped(name string, escape bool) error {
+func (t *TestClientRequest) SetPathParamEscaped(_ string, _ bool) error {
 	return nil
 }
 

--- a/client_request.go
+++ b/client_request.go
@@ -50,6 +50,8 @@ type ClientRequest interface {
 
 	SetPathParam(string, string) error
 
+	SetPathParamEscaped(name string, escape bool) error
+
 	GetQueryParams() url.Values
 
 	SetFileParam(string, ...NamedReadCloser) error
@@ -120,6 +122,10 @@ func (t *TestClientRequest) SetQueryParam(_ string, _ ...string) error { return 
 func (t *TestClientRequest) SetFormParam(_ string, _ ...string) error { return nil }
 
 func (t *TestClientRequest) SetPathParam(_ string, _ string) error { return nil }
+
+func (t *TestClientRequest) SetPathParamEscaped(name string, escape bool) error {
+	return nil
+}
 
 func (t *TestClientRequest) SetFileParam(_ string, _ ...NamedReadCloser) error { return nil }
 


### PR DESCRIPTION
Provide a way to control path parmas.

fix https://github.com/go-openapi/runtime/issues/138