### PR TITLE
chore: add CreateHttpRequest

### DIFF
--- a/client/runtime.go
+++ b/client/runtime.go
@@ -358,20 +358,19 @@ func (r *Runtime) EnableConnectionReuse() {
 	)
 }
 
-// Submit a request and when there is a body on success it will turn that into the result
-// all other things are turned into an api error for swagger which retains the status code
-func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error) {
-	params, readResponse, auth := operation.Params, operation.Reader, operation.AuthInfo
+// takes a client operation and creates equivalent http.Request
+func (r *Runtime) createHttpRequest(operation *runtime.ClientOperation) (*request, *http.Request, error) {
+	params, _, auth := operation.Params, operation.Reader, operation.AuthInfo
 
 	request, err := newRequest(operation.Method, operation.PathPattern, params)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	var accept []string
 	accept = append(accept, operation.ProducesMediaTypes...)
 	if err = request.SetHeaderParam(runtime.HeaderAccept, accept...); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	if auth == nil && r.DefaultAuthentication != nil {
@@ -399,16 +398,33 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 	}
 
 	if _, ok := r.Producers[cmt]; !ok && cmt != runtime.MultipartFormMime && cmt != runtime.URLencodedFormMime {
-		return nil, fmt.Errorf("none of producers: %v registered. try %s", r.Producers, cmt)
+		return nil, nil, fmt.Errorf("none of producers: %v registered. try %s", r.Producers, cmt)
 	}
 
 	req, err := request.buildHTTP(cmt, r.BasePath, r.Producers, r.Formats, auth)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	req.URL.Scheme = r.pickScheme(operation.Schemes)
 	req.URL.Host = r.Host
 	req.Host = r.Host
+	return request, req, nil
+}
+
+func (r *Runtime) CreateHttpRequest(operation *runtime.ClientOperation) (req *http.Request, err error) {
+	_, req, err = r.createHttpRequest(operation)
+	return
+}
+
+// Submit a request and when there is a body on success it will turn that into the result
+// all other things are turned into an api error for swagger which retains the status code
+func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error) {
+	_, readResponse, _ := operation.Params, operation.Reader, operation.AuthInfo
+
+	request, req, err := r.createHttpRequest(operation)
+	if err != nil {
+		return nil, err
+	}
 
 	r.clientOnce.Do(func() {
 		r.client = &http.Client{


### PR DESCRIPTION
Refactors code to expose CreateHttpRequest which can be used as utility to convert a swagger operation to an http.Request.