### PR TITLE
fix APIError to always report errors

### DIFF
--- a/client_response.go
+++ b/client_response.go
@@ -15,10 +15,9 @@
 package runtime
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
-
-	"encoding/json"
 )
 
 // A ClientResponse represents a client response
@@ -61,13 +60,18 @@ type APIError struct {
 	Code          int
 }
 
-func (a *APIError) Error() string {
-	resp, _ := json.Marshal(a.Response)
-	return fmt.Sprintf("%s (status %d): %s", a.OperationName, a.Code, resp)
+func (o *APIError) Error() string {
+	var resp []byte
+	if err, ok := o.Response.(error); ok {
+		resp = []byte("'" + err.Error() + "'")
+	} else {
+		resp, _ = json.Marshal(o.Response)
+	}
+	return fmt.Sprintf("%s (status %d): %s", o.OperationName, o.Code, resp)
 }
 
-func (a *APIError) String() string {
-	return a.Error()
+func (o *APIError) String() string {
+	return o.Error()
 }
 
 // IsSuccess returns true when this elapse o k response returns a 2xx status code


### PR DESCRIPTION
Command `swagger generate client` is generating client code looking like this:

```
// ReadResponse reads a server response into the received o.
func (o *DownloadQPartReader) ReadResponse(response runtime.ClientResponse, consumer runtime.Consumer) (interface{}, error) {


	readResponseError := func(err error) error {
		if response.Code()/100 == 2 {
			// that's a real error reading the response,
			// we might as well discard the response code ...
			return runtime.NewAPIError("read response", err, response.Code())
		}
		// now we're reading a potential error.. but if none don't say it's an error
		if err == io.EOF {
			err = nil
		}
		return runtime.NewAPIError("read response", err, response.Code())
	}

	switch response.Code() {

	case 200:
...
```

With errors that do not implement json marshalling the original error is wipped of the output:

```
cause [read response (status 200): {}]
```

After applying the patch:

```
cause [read response (status 200): 'write /path/to/my/file: no space left on device']
```
