### PR TITLE
fix produces with type parameter

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -498,7 +498,9 @@ func (c *Context) Respond(rw http.ResponseWriter, r *http.Request, produces []st
 
 	if resp, ok := data.(Responder); ok {
 		producers := route.Producers
-		prod, ok := producers[format]
+		// producers contains keys with normalized format, if a format has MIME type parameter such as `text/plain; charset=utf-8`
+		// then you must provide `text/plain` to get the correct producer. HOWEVER, format here is not normalized.
+		prod, ok := producers[normalizeOffer(format)]
 		if !ok {
 			prods := c.api.ProducersFor(normalizeOffers([]string{c.api.DefaultProduces()}))
 			pr, ok := prods[c.api.DefaultProduces()]


### PR DESCRIPTION
A path object can specify `produces` with an array of `MIME` types, as shown following:

```yaml
/path:
    produces:
          - text/plain; charset=utf-8
    ....
```
In the latest release, the MIME-type parameters(`charset=utf-8` in this case) is normalized and ignored and we get a map from the `normalized MIME type` to the `runtime.Producer`. However, when determining what `runtime.Producer`  to use to response to the client, it uses the unnormalized MIME type.
```yaml
var format string
format, r = c.ResponseFormat(r, offers)
rw.Header().Set(runtime.HeaderContentType, format)

if resp, ok := data.(Responder); ok {
	producers := route.Producers
	prod, ok := producers[format]
```
