### PR TITLE
Add swagger oath2 callback

### DIFF
--- a/client/response.go
+++ b/client/response.go
@@ -23,6 +23,8 @@ import (
 
 var _ runtime.ClientResponse = response{}
 
+func newResponse(resp *http.Response) runtime.ClientResponse { return response{resp: resp} }
+
 type response struct {
 	resp *http.Response
 }

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -225,7 +225,7 @@ type Runtime struct {
 
 	Transport http.RoundTripper
 	Jar       http.CookieJar
-	//Spec      *spec.Document
+	// Spec      *spec.Document
 	Host     string
 	BasePath string
 	Formats  strfmt.Registry
@@ -237,6 +237,7 @@ type Runtime struct {
 	clientOnce *sync.Once
 	client     *http.Client
 	schemes    []string
+	response   ClientResponseFunc
 }
 
 // New creates a new default runtime for a swagger api runtime.Client
@@ -275,6 +276,7 @@ func New(host, basePath string, schemes []string) *Runtime {
 
 	rt.Debug = logger.DebugEnabled()
 	rt.logger = logger.StandardLogger{}
+	rt.response = newResponse
 
 	if len(schemes) > 0 {
 		rt.schemes = schemes
@@ -329,6 +331,7 @@ func (r *Runtime) selectScheme(schemes []string) string {
 	}
 	return scheme
 }
+
 func transportOrDefault(left, right http.RoundTripper) http.RoundTripper {
 	if left == nil {
 		return right
@@ -381,7 +384,7 @@ func (r *Runtime) createHttpRequest(operation *runtime.ClientOperation) (*reques
 			return r.DefaultAuthentication.AuthenticateRequest(req, reg)
 		})
 	}
-	//if auth != nil {
+	// if auth != nil {
 	//	if err := auth.AuthenticateRequest(request, r.Formats); err != nil {
 	//		return nil, err
 	//	}
@@ -500,7 +503,7 @@ func (r *Runtime) Submit(operation *runtime.ClientOperation) (interface{}, error
 			return nil, fmt.Errorf("no consumer: %q", ct)
 		}
 	}
-	return readResponse.ReadResponse(response{res}, cons)
+	return readResponse.ReadResponse(r.response(res), cons)
 }
 
 // SetDebug changes the debug flag.
@@ -515,4 +518,14 @@ func (r *Runtime) SetDebug(debug bool) {
 func (r *Runtime) SetLogger(logger logger.Logger) {
 	r.logger = logger
 	middleware.Logger = logger
+}
+
+type ClientResponseFunc = func(*http.Response) runtime.ClientResponse
+
+// SetResponseReader changes the response reader implementation.
+func (r *Runtime) SetResponseReader(f ClientResponseFunc) {
+	if f == nil {
+		return
+	}
+	r.response = f
 }

--- a/middleware/swaggerui.go
+++ b/middleware/swaggerui.go
@@ -16,6 +16,8 @@ type SwaggerUIOpts struct {
 	Path string
 	// SpecURL the url to find the spec for
 	SpecURL string
+	// OAuthCallbackURL the url called after OAuth2 login
+	OAuthCallbackURL string
 
 	// The three components needed to embed swagger-ui
 	SwaggerURL       string
@@ -39,6 +41,9 @@ func (r *SwaggerUIOpts) EnsureDefaults() {
 	}
 	if r.SpecURL == "" {
 		r.SpecURL = "/swagger.json"
+	}
+	if r.OAuthCallbackURL == "" {
+		r.OAuthCallbackURL = path.Join(r.BasePath, r.Path, "oauth2-callback")
 	}
 	if r.SwaggerURL == "" {
 		r.SwaggerURL = swaggerLatest
@@ -149,7 +154,8 @@ const (
         plugins: [
           SwaggerUIBundle.plugins.DownloadUrl
         ],
-        layout: "StandaloneLayout"
+        layout: "StandaloneLayout",
+		oauth2RedirectUrl: '{{ .OAuthCallbackURL }}'
       })
       // End Swagger UI call region
 

--- a/middleware/swaggerui_oauth2.go
+++ b/middleware/swaggerui_oauth2.go
@@ -1,0 +1,122 @@
+package middleware
+
+import (
+	"bytes"
+	"fmt"
+	"net/http"
+	"path"
+	"text/template"
+)
+
+func SwaggerUIOAuth2Callback(opts SwaggerUIOpts, next http.Handler) http.Handler {
+	opts.EnsureDefaults()
+
+	pth := opts.OAuthCallbackURL
+	tmpl := template.Must(template.New("swaggeroauth").Parse(swaggerOAuthTemplate))
+
+	buf := bytes.NewBuffer(nil)
+	_ = tmpl.Execute(buf, &opts)
+	b := buf.Bytes()
+
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if path.Join(r.URL.Path) == pth {
+			rw.Header().Set("Content-Type", "text/html; charset=utf-8")
+			rw.WriteHeader(http.StatusOK)
+
+			_, _ = rw.Write(b)
+			return
+		}
+
+		if next == nil {
+			rw.Header().Set("Content-Type", "text/plain")
+			rw.WriteHeader(http.StatusNotFound)
+			_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
+			return
+		}
+		next.ServeHTTP(rw, r)
+	})
+}
+
+const (
+	swaggerOAuthTemplate = `
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <title>{{ .Title }}</title>
+</head>
+<body>
+<script>
+    'use strict';
+    function run () {
+        var oauth2 = window.opener.swaggerUIRedirectOauth2;
+        var sentState = oauth2.state;
+        var redirectUrl = oauth2.redirectUrl;
+        var isValid, qp, arr;
+
+        if (/code|token|error/.test(window.location.hash)) {
+            qp = window.location.hash.substring(1).replace('?', '&');
+        } else {
+            qp = location.search.substring(1);
+        }
+
+        arr = qp.split("&");
+        arr.forEach(function (v,i,_arr) { _arr[i] = '"' + v.replace('=', '":"') + '"';});
+        qp = qp ? JSON.parse('{' + arr.join() + '}',
+                function (key, value) {
+                    return key === "" ? value : decodeURIComponent(value);
+                }
+        ) : {};
+
+        isValid = qp.state === sentState;
+
+        if ((
+          oauth2.auth.schema.get("flow") === "accessCode" ||
+          oauth2.auth.schema.get("flow") === "authorizationCode" ||
+          oauth2.auth.schema.get("flow") === "authorization_code"
+        ) && !oauth2.auth.code) {
+            if (!isValid) {
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "warning",
+                    message: "Authorization may be unsafe, passed state was changed in server. The passed state wasn't returned from auth server."
+                });
+            }
+
+            if (qp.code) {
+                delete oauth2.state;
+                oauth2.auth.code = qp.code;
+                oauth2.callback({auth: oauth2.auth, redirectUrl: redirectUrl});
+            } else {
+                let oauthErrorMsg;
+                if (qp.error) {
+                    oauthErrorMsg = "["+qp.error+"]: " +
+                        (qp.error_description ? qp.error_description+ ". " : "no accessCode received from the server. ") +
+                        (qp.error_uri ? "More info: "+qp.error_uri : "");
+                }
+
+                oauth2.errCb({
+                    authId: oauth2.auth.name,
+                    source: "auth",
+                    level: "error",
+                    message: oauthErrorMsg || "[Authorization failed]: no accessCode received from the server."
+                });
+            }
+        } else {
+            oauth2.callback({auth: oauth2.auth, token: qp, isValid: isValid, redirectUrl: redirectUrl});
+        }
+        window.close();
+    }
+
+    if (document.readyState !== 'loading') {
+        run();
+    } else {
+        document.addEventListener('DOMContentLoaded', function () {
+            run();
+        });
+    }
+</script>
+</body>
+</html>
+	`
+)

--- a/middleware/swaggerui_oauth2.go
+++ b/middleware/swaggerui_oauth2.go
@@ -118,5 +118,5 @@ const (
 </script>
 </body>
 </html>
-	`
+`
 )

--- a/middleware/swaggerui_oauth2_test.go
+++ b/middleware/swaggerui_oauth2_test.go
@@ -1,0 +1,20 @@
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSwaggerUIOAuth2CallbackMiddleware(t *testing.T) {
+	redoc := SwaggerUIOAuth2Callback(SwaggerUIOpts{}, nil)
+
+	req, _ := http.NewRequest("GET", "/docs/oauth2-callback", nil)
+	recorder := httptest.NewRecorder()
+	redoc.ServeHTTP(recorder, req)
+	assert.Equal(t, 200, recorder.Code)
+	assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
+	assert.Contains(t, recorder.Body.String(), "<title>API documentation</title>")
+}


### PR DESCRIPTION
Implemented swagger oauth2 callback page to have working oauth2 authentication flow on swaggerUI middleware.

Fixes #255 

Example usage:
```
swaggerOptions := middleware.SwaggerUIOpts{}
swaggerHandler := middleware.SwaggerUI(swaggerOptions, nil)
swaggerOAuthHandler := middleware.SwaggerUIOAuth(swaggerOptions, nil)
router.Handle("/docs", swaggerHandler)
router.Handle("/docs/oauth2-callback", swaggerOAuthHandler)
```
