### PR TITLE
Add middleware.NewRoutableContextWithAnalyzedSpec()

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -195,6 +195,17 @@ func NewRoutableContext(spec *loads.Document, routableAPI RoutableAPI, routes Ro
 	if spec != nil {
 		an = analysis.New(spec.Spec())
 	}
+
+	return NewRoutableContextWithAnalyzedSpec(spec, an, routableAPI, routes)
+}
+
+// NewRoutableContextWithAnalyzedSpec is like NewRoutableContext but takes in input the analysed spec too
+func NewRoutableContextWithAnalyzedSpec(spec *loads.Document, an *analysis.Spec, routableAPI RoutableAPI, routes Router) *Context {
+	// Either there are no spec doc and analysis, or both of them.
+	if !((spec == nil && an == nil) || (spec != nil && an != nil)) {
+		panic(errors.New(http.StatusInternalServerError, "routable context requires either both spec doc and analysis, or none of them"))
+	}
+
 	ctx := &Context{spec: spec, api: routableAPI, analyzer: an, router: routes}
 	return ctx
 }


### PR DESCRIPTION
In Grafana Mimir we have an use case where it would be very handy if we could create a routable context passing the analysed spec too. In this PR I'm proposing to add a new function to create a routable context taking in input both the spec doc and analysis.

## The use case

Grafana Mimir is a multi-tenant system. A specific component (Alertmanager) uses the swagger and this project to define the API. The way the alertmanager is implemented is to create a different instance of the API implementation for each tenant. Each API implementation instance, among other things, call `runtime.NewRoutableContext()` which cascading call `analysis.New()`.

The API implementation instance is different for each tenant, but the actual API specs don't change, so the result of `analysis.New()` is not different on a per-tenant basis. In a system with thousands of tenants, `analysis.New()` allocates the majority of the memory of the process (hundreds of GB in a large system).

The new function proposed in this PR would allow us to create a routable context for each tenant but passing the same analysed spec for each of them (given the API spec doesn't change between tenants).