### PR TITLE
Add context to client error messages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ coverage.out
 *.cov
 *.out
 playground
+.idea


### PR DESCRIPTION
Adds context to all error messages in the `client` package. Before this change it was pretty hard to debug some of the issues when errors looked similar to below:
```
Post "http://localhost:8080/": EOF
```
With this PR in place, errors are now much more verbose and are at least giving some insights what could went wrong.