### PR TITLE
handle EOF when detect content type

### DIFF
--- a/client/request.go
+++ b/client/request.go
@@ -170,7 +170,7 @@ func (r *request) buildHTTP(mediaType, basePath string, producers map[string]run
 						// Need to read the data so that we can detect the content type
 						buf := make([]byte, 512)
 						size, err := fi.Read(buf)
-						if err != nil {
+						if err != nil && err != io.EOF {
 							logClose(err, pw)
 							return
 						}

--- a/client/request_test.go
+++ b/client/request_test.go
@@ -389,10 +389,12 @@ func TestBuildRequest_BuildHTTP_FormMultiples(t *testing.T) {
 func TestBuildRequest_BuildHTTP_Files(t *testing.T) {
 	cont, _ := os.ReadFile("./runtime.go")
 	cont2, _ := os.ReadFile("./request.go")
+	emptyFile, _ := os.CreateTemp("", "empty")
 	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, reg strfmt.Registry) error {
 		_ = req.SetFormParam("something", "some value")
 		_ = req.SetFileParam("file", mustGetFile("./runtime.go"))
 		_ = req.SetFileParam("otherfiles", mustGetFile("./runtime.go"), mustGetFile("./request.go"))
+		_ = req.SetFileParam("empty", emptyFile)
 		_ = req.SetQueryParam("hello", "world")
 		_ = req.SetPathParam("id", "1234")
 		_ = req.SetHeaderParam("X-Rate-Limit", "200")
@@ -426,6 +428,8 @@ func TestBuildRequest_BuildHTTP_Files(t *testing.T) {
 
 				fileverifier("otherfiles", 0, "runtime.go", cont)
 				fileverifier("otherfiles", 1, "request.go", cont2)
+
+				fileverifier("empty", 0, filepath.Base(emptyFile.Name()), []byte{})
 			}
 		}
 	}


### PR DESCRIPTION
We should handle EOF error when using file.Read(). Specifically, when uploading empty file, it returns EOF error when reading the file, but it is expected.