### PR TITLE
feat: more options for UI middleware

### DIFF
--- a/middleware/rapidoc.go
+++ b/middleware/rapidoc.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package middleware
 
 import (
@@ -11,66 +10,57 @@ import (
 
 // RapiDocOpts configures the RapiDoc middlewares
 type RapiDocOpts struct {
-	// BasePath for the UI path, defaults to: /
+	// BasePath for the UI, defaults to: /
 	BasePath string
-	// Path combines with BasePath for the full UI path, defaults to: docs
+
+	// Path combines with BasePath to construct the path to the UI, defaults to: "docs".
 	Path string
-	// SpecURL the url to find the spec for
+
+	// SpecURL is the URL of the spec document.
+	//
+	// Defaults to: /swagger.json
 	SpecURL string
-	// RapiDocURL for the js that generates the rapidoc site, defaults to: https://cdn.jsdelivr.net/npm/rapidoc/bundles/rapidoc.standalone.js
-	RapiDocURL string
+
 	// Title for the documentation site, default to: API documentation
 	Title string
+
+	// Template specifies a custom template to serve the UI
+	Template string
+
+	// RapiDocURL points to the js asset that generates the rapidoc site.
+	//
+	// Defaults to https://unpkg.com/rapidoc/dist/rapidoc-min.js
+	RapiDocURL string
 }
 
-// EnsureDefaults in case some options are missing
 func (r *RapiDocOpts) EnsureDefaults() {
-	if r.BasePath == "" {
-		r.BasePath = "/"
-	}
-	if r.Path == "" {
-		r.Path = defaultDocsPath
-	}
-	if r.SpecURL == "" {
-		r.SpecURL = defaultDocsURL
-	}
+	common := toCommonUIOptions(r)
+	common.EnsureDefaults()
+	fromCommonToAnyOptions(common, r)
+
+	// rapidoc-specifics
 	if r.RapiDocURL == "" {
 		r.RapiDocURL = rapidocLatest
 	}
-	if r.Title == "" {
-		r.Title = defaultDocsTitle
+	if r.Template == "" {
+		r.Template = rapidocTemplate
 	}
 }
 
 // RapiDoc creates a middleware to serve a documentation site for a swagger spec.
+//
 // This allows for altering the spec before starting the http listener.
 func RapiDoc(opts RapiDocOpts, next http.Handler) http.Handler {
 	opts.EnsureDefaults()
 
 	pth := path.Join(opts.BasePath, opts.Path)
-	tmpl := template.Must(template.New("rapidoc").Parse(rapidocTemplate))
+	tmpl := template.Must(template.New("rapidoc").Parse(opts.Template))
+	assets := bytes.NewBuffer(nil)
+	if err := tmpl.Execute(assets, opts); err != nil {
+		panic(fmt.Errorf("cannot execute template: %w", err))
+	}
 
-	buf := bytes.NewBuffer(nil)
-	_ = tmpl.Execute(buf, opts)
-	b := buf.Bytes()
-
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == pth {
-			rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-			rw.WriteHeader(http.StatusOK)
-
-			_, _ = rw.Write(b)
-			return
-		}
-
-		if next == nil {
-			rw.Header().Set("Content-Type", "text/plain")
-			rw.WriteHeader(http.StatusNotFound)
-			_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
+	return serveUI(pth, assets.Bytes(), next)
 }
 
 const (

--- a/middleware/rapidoc_test.go
+++ b/middleware/rapidoc_test.go
@@ -12,17 +12,33 @@ import (
 )
 
 func TestRapiDocMiddleware(t *testing.T) {
-	rapidoc := RapiDoc(RapiDocOpts{}, nil)
+	t.Run("with defaults", func(t *testing.T) {
+		rapidoc := RapiDoc(RapiDocOpts{}, nil)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
-	require.NoError(t, err)
-	recorder := httptest.NewRecorder()
-	rapidoc.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
-	var o RapiDocOpts
-	o.EnsureDefaults()
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<rapi-doc spec-url=%q></rapi-doc>", o.SpecURL))
-	assert.Contains(t, recorder.Body.String(), rapidocLatest)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		rapidoc.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get(contentTypeHeader))
+		var o RapiDocOpts
+		o.EnsureDefaults()
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<rapi-doc spec-url=%q></rapi-doc>", o.SpecURL))
+		assert.Contains(t, recorder.Body.String(), rapidocLatest)
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("with custom template that fails to execute", func(t *testing.T) {
+			assert.Panics(t, func() {
+				RapiDoc(RapiDocOpts{
+					Template: `<!DOCTYPE html>
+<html>
+	spec-url='{{ .Unknown }}'
+</html>
+`,
+				}, nil)
+			})
+		})
+	})
 }

--- a/middleware/redoc.go
+++ b/middleware/redoc.go
@@ -1,4 +1,3 @@
-//nolint:dupl
 package middleware
 
 import (
@@ -11,66 +10,58 @@ import (
 
 // RedocOpts configures the Redoc middlewares
 type RedocOpts struct {
-	// BasePath for the UI path, defaults to: /
+	// BasePath for the UI, defaults to: /
 	BasePath string
-	// Path combines with BasePath for the full UI path, defaults to: docs
+
+	// Path combines with BasePath to construct the path to the UI, defaults to: "docs".
 	Path string
-	// SpecURL the url to find the spec for
+
+	// SpecURL is the URL of the spec document.
+	//
+	// Defaults to: /swagger.json
 	SpecURL string
-	// RedocURL for the js that generates the redoc site, defaults to: https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js
-	RedocURL string
+
 	// Title for the documentation site, default to: API documentation
 	Title string
+
+	// Template specifies a custom template to serve the UI
+	Template string
+
+	// RedocURL points to the js that generates the redoc site.
+	//
+	// Defaults to: https://cdn.jsdelivr.net/npm/redoc/bundles/redoc.standalone.js
+	RedocURL string
 }
 
 // EnsureDefaults in case some options are missing
 func (r *RedocOpts) EnsureDefaults() {
-	if r.BasePath == "" {
-		r.BasePath = "/"
-	}
-	if r.Path == "" {
-		r.Path = defaultDocsPath
-	}
-	if r.SpecURL == "" {
-		r.SpecURL = defaultDocsURL
-	}
+	common := toCommonUIOptions(r)
+	common.EnsureDefaults()
+	fromCommonToAnyOptions(common, r)
+
+	// redoc-specifics
 	if r.RedocURL == "" {
 		r.RedocURL = redocLatest
 	}
-	if r.Title == "" {
-		r.Title = defaultDocsTitle
+	if r.Template == "" {
+		r.Template = redocTemplate
 	}
 }
 
 // Redoc creates a middleware to serve a documentation site for a swagger spec.
+//
 // This allows for altering the spec before starting the http listener.
 func Redoc(opts RedocOpts, next http.Handler) http.Handler {
 	opts.EnsureDefaults()
 
 	pth := path.Join(opts.BasePath, opts.Path)
-	tmpl := template.Must(template.New("redoc").Parse(redocTemplate))
+	tmpl := template.Must(template.New("redoc").Parse(opts.Template))
+	assets := bytes.NewBuffer(nil)
+	if err := tmpl.Execute(assets, opts); err != nil {
+		panic(fmt.Errorf("cannot execute template: %w", err))
+	}
 
-	buf := bytes.NewBuffer(nil)
-	_ = tmpl.Execute(buf, opts)
-	b := buf.Bytes()
-
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == pth {
-			rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-			rw.WriteHeader(http.StatusOK)
-
-			_, _ = rw.Write(b)
-			return
-		}
-
-		if next == nil {
-			rw.Header().Set("Content-Type", "text/plain")
-			rw.WriteHeader(http.StatusNotFound)
-			_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
+	return serveUI(pth, assets.Bytes(), next)
 }
 
 const (

--- a/middleware/redoc_test.go
+++ b/middleware/redoc_test.go
@@ -12,17 +12,105 @@ import (
 )
 
 func TestRedocMiddleware(t *testing.T) {
-	redoc := Redoc(RedocOpts{}, nil)
+	t.Run("with defaults", func(t *testing.T) {
+		redoc := Redoc(RedocOpts{}, nil)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
-	require.NoError(t, err)
-	recorder := httptest.NewRecorder()
-	redoc.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
-	var o RedocOpts
-	o.EnsureDefaults()
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<redoc spec-url='%s'></redoc>", o.SpecURL))
-	assert.Contains(t, recorder.Body.String(), redocLatest)
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		redoc.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get(contentTypeHeader))
+		var o RedocOpts
+		o.EnsureDefaults()
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<redoc spec-url='%s'></redoc>", o.SpecURL))
+		assert.Contains(t, recorder.Body.String(), redocLatest)
+	})
+
+	t.Run("with alternate path and spec URL", func(t *testing.T) {
+		redoc := Redoc(RedocOpts{
+			BasePath: "/base",
+			Path:     "ui",
+			SpecURL:  "/ui/swagger.json",
+		}, nil)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/base/ui", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		redoc.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "<redoc spec-url='/ui/swagger.json'></redoc>")
+	})
+
+	t.Run("with custom template", func(t *testing.T) {
+		redoc := Redoc(RedocOpts{
+			Template: `<!DOCTYPE html>
+<html>
+  <head>
+    <title>{{ .Title }}</title>
+		<meta charset="utf-8"/>
+		<meta name="viewport" content="width=device-width, initial-scale=1">
+		<link href="https://fonts.googleapis.com/css?family=Montserrat:300,400,700|Roboto:300,400,700" rel="stylesheet">
+
+    <!--
+    ReDoc doesn't change outer page styles
+    -->
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+      }
+    </style>
+  </head>
+  <body>
+    <redoc
+				spec-url='{{ .SpecURL }}'
+				required-props-first=true
+        theme='{
+         "sidebar": {
+           "backgroundColor": "lightblue"
+         }
+        }'
+		></redoc>
+    <script src="{{ .RedocURL }}"> </script>
+  </body>
+</html>
+`,
+		}, nil)
+
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+		redoc.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Contains(t, recorder.Body.String(), "required-props-first=true")
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("with invalid custom template", func(t *testing.T) {
+			assert.Panics(t, func() {
+				Redoc(RedocOpts{
+					Template: `<!DOCTYPE html>
+<html>
+  <head>
+				spec-url='{{ .Spec
+</html>
+`,
+				}, nil)
+			})
+		})
+
+		t.Run("with custom template that fails to execute", func(t *testing.T) {
+			assert.Panics(t, func() {
+				Redoc(RedocOpts{
+					Template: `<!DOCTYPE html>
+<html>
+	spec-url='{{ .Unknown }}'
+</html>
+`,
+				}, nil)
+			})
+		})
+	})
 }

--- a/middleware/spec.go
+++ b/middleware/spec.go
@@ -19,29 +19,84 @@ import (
 	"path"
 )
 
-// Spec creates a middleware to serve a swagger spec.
+const (
+	contentTypeHeader = "Content-Type"
+	applicationJSON   = "application/json"
+)
+
+// SpecOption can be applied to the Spec serving middleware
+type SpecOption func(*specOptions)
+
+var defaultSpecOptions = specOptions{
+	Path:     "",
+	Document: "swagger.json",
+}
+
+type specOptions struct {
+	Path     string
+	Document string
+}
+
+func specOptionsWithDefaults(opts []SpecOption) specOptions {
+	o := defaultSpecOptions
+	for _, apply := range opts {
+		apply(&o)
+	}
+
+	return o
+}
+
+// Spec creates a middleware to serve a swagger spec as a JSON document.
+//
 // This allows for altering the spec before starting the http listener.
-// This can be useful if you want to serve the swagger spec from another path than /swagger.json
-func Spec(basePath string, b []byte, next http.Handler) http.Handler {
+//
+// The basePath argument indicates the path of the spec document (defaults to "/").
+// Additional SpecOption can be used to change the name of the document (defaults to "swagger.json").
+func Spec(basePath string, b []byte, next http.Handler, opts ...SpecOption) http.Handler {
 	if basePath == "" {
 		basePath = "/"
 	}
-	pth := path.Join(basePath, "swagger.json")
+	o := specOptionsWithDefaults(opts)
+	pth := path.Join(basePath, o.Path, o.Document)
 
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if r.URL.Path == pth {
-			rw.Header().Set("Content-Type", "application/json")
+		if path.Clean(r.URL.Path) == pth {
+			rw.Header().Set(contentTypeHeader, applicationJSON)
 			rw.WriteHeader(http.StatusOK)
-			//#nosec
 			_, _ = rw.Write(b)
+
 			return
 		}
 
-		if next == nil {
-			rw.Header().Set("Content-Type", "application/json")
-			rw.WriteHeader(http.StatusNotFound)
+		if next != nil {
+			next.ServeHTTP(rw, r)
+
 			return
 		}
-		next.ServeHTTP(rw, r)
+
+		rw.Header().Set(contentTypeHeader, applicationJSON)
+		rw.WriteHeader(http.StatusNotFound)
 	})
+}
+
+// WithSpecPath sets the path to be joined to the base path of the Spec middleware.
+//
+// This is empty by default.
+func WithSpecPath(pth string) SpecOption {
+	return func(o *specOptions) {
+		o.Path = pth
+	}
+}
+
+// WithSpecDocument sets the name of the JSON document served as a spec.
+//
+// By default, this is "swagger.json"
+func WithSpecDocument(doc string) SpecOption {
+	return func(o *specOptions) {
+		if doc == "" {
+			return
+		}
+
+		o.Document = doc
+	}
 }

--- a/middleware/swaggerui.go
+++ b/middleware/swaggerui.go
@@ -8,40 +8,65 @@ import (
 	"path"
 )
 
-// SwaggerUIOpts configures the Swaggerui middlewares
+// SwaggerUIOpts configures the SwaggerUI middleware
 type SwaggerUIOpts struct {
-	// BasePath for the UI path, defaults to: /
+	// BasePath for the API, defaults to: /
 	BasePath string
-	// Path combines with BasePath for the full UI path, defaults to: docs
+
+	// Path combines with BasePath to construct the path to the UI, defaults to: "docs".
 	Path string
-	// SpecURL the url to find the spec for
+
+	// SpecURL is the URL of the spec document.
+	//
+	// Defaults to: /swagger.json
 	SpecURL string
+
+	// Title for the documentation site, default to: API documentation
+	Title string
+
+	// Template specifies a custom template to serve the UI
+	Template string
+
 	// OAuthCallbackURL the url called after OAuth2 login
 	OAuthCallbackURL string
 
 	// The three components needed to embed swagger-ui
-	SwaggerURL       string
+
+	// SwaggerURL points to the js that generates the SwaggerUI site.
+	//
+	// Defaults to: https://unpkg.com/swagger-ui-dist/swagger-ui-bundle.js
+	SwaggerURL string
+
 	SwaggerPresetURL string
 	SwaggerStylesURL string
 
 	Favicon32 string
 	Favicon16 string
-
-	// Title for the documentation site, default to: API documentation
-	Title string
 }
 
 // EnsureDefaults in case some options are missing
 func (r *SwaggerUIOpts) EnsureDefaults() {
-	if r.BasePath == "" {
-		r.BasePath = "/"
+	r.ensureDefaults()
+
+	if r.Template == "" {
+		r.Template = swaggeruiTemplate
 	}
-	if r.Path == "" {
-		r.Path = defaultDocsPath
+}
+
+func (r *SwaggerUIOpts) EnsureDefaultsOauth2() {
+	r.ensureDefaults()
+
+	if r.Template == "" {
+		r.Template = swaggerOAuthTemplate
 	}
-	if r.SpecURL == "" {
-		r.SpecURL = defaultDocsURL
-	}
+}
+
+func (r *SwaggerUIOpts) ensureDefaults() {
+	common := toCommonUIOptions(r)
+	common.EnsureDefaults()
+	fromCommonToAnyOptions(common, r)
+
+	// swaggerui-specifics
 	if r.OAuthCallbackURL == "" {
 		r.OAuthCallbackURL = path.Join(r.BasePath, r.Path, "oauth2-callback")
 	}
@@ -60,40 +85,22 @@ func (r *SwaggerUIOpts) EnsureDefaults() {
 	if r.Favicon32 == "" {
 		r.Favicon32 = swaggerFavicon32Latest
 	}
-	if r.Title == "" {
-		r.Title = defaultDocsTitle
-	}
 }
 
 // SwaggerUI creates a middleware to serve a documentation site for a swagger spec.
+//
 // This allows for altering the spec before starting the http listener.
 func SwaggerUI(opts SwaggerUIOpts, next http.Handler) http.Handler {
 	opts.EnsureDefaults()
 
 	pth := path.Join(opts.BasePath, opts.Path)
-	tmpl := template.Must(template.New("swaggerui").Parse(swaggeruiTemplate))
+	tmpl := template.Must(template.New("swaggerui").Parse(opts.Template))
+	assets := bytes.NewBuffer(nil)
+	if err := tmpl.Execute(assets, opts); err != nil {
+		panic(fmt.Errorf("cannot execute template: %w", err))
+	}
 
-	buf := bytes.NewBuffer(nil)
-	_ = tmpl.Execute(buf, &opts)
-	b := buf.Bytes()
-
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if path.Join(r.URL.Path) == pth {
-			rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-			rw.WriteHeader(http.StatusOK)
-
-			_, _ = rw.Write(b)
-			return
-		}
-
-		if next == nil {
-			rw.Header().Set("Content-Type", "text/plain")
-			rw.WriteHeader(http.StatusNotFound)
-			_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
+	return serveUI(pth, assets.Bytes(), next)
 }
 
 const (

--- a/middleware/swaggerui_oauth2.go
+++ b/middleware/swaggerui_oauth2.go
@@ -4,37 +4,20 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
-	"path"
 	"text/template"
 )
 
 func SwaggerUIOAuth2Callback(opts SwaggerUIOpts, next http.Handler) http.Handler {
-	opts.EnsureDefaults()
+	opts.EnsureDefaultsOauth2()
 
 	pth := opts.OAuthCallbackURL
-	tmpl := template.Must(template.New("swaggeroauth").Parse(swaggerOAuthTemplate))
+	tmpl := template.Must(template.New("swaggeroauth").Parse(opts.Template))
+	assets := bytes.NewBuffer(nil)
+	if err := tmpl.Execute(assets, opts); err != nil {
+		panic(fmt.Errorf("cannot execute template: %w", err))
+	}
 
-	buf := bytes.NewBuffer(nil)
-	_ = tmpl.Execute(buf, &opts)
-	b := buf.Bytes()
-
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if path.Join(r.URL.Path) == pth {
-			rw.Header().Set("Content-Type", "text/html; charset=utf-8")
-			rw.WriteHeader(http.StatusOK)
-
-			_, _ = rw.Write(b)
-			return
-		}
-
-		if next == nil {
-			rw.Header().Set("Content-Type", "text/plain")
-			rw.WriteHeader(http.StatusNotFound)
-			_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
-			return
-		}
-		next.ServeHTTP(rw, r)
-	})
+	return serveUI(pth, assets.Bytes(), next)
 }
 
 const (

--- a/middleware/swaggerui_test.go
+++ b/middleware/swaggerui_test.go
@@ -17,17 +17,53 @@ func TestSwaggerUIMiddleware(t *testing.T) {
 	o.EnsureDefaults()
 	swui := SwaggerUI(o, nil)
 
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
-	require.NoError(t, err)
-	recorder := httptest.NewRecorder()
-	swui.ServeHTTP(recorder, req)
-	assert.Equal(t, http.StatusOK, recorder.Code)
-	assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get("Content-Type"))
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
-	assert.Contains(t, recorder.Body.String(), fmt.Sprintf(`url: '%s',`, strings.ReplaceAll(o.SpecURL, `/`, `\/`)))
-	assert.Contains(t, recorder.Body.String(), swaggerLatest)
-	assert.Contains(t, recorder.Body.String(), swaggerPresetLatest)
-	assert.Contains(t, recorder.Body.String(), swaggerStylesLatest)
-	assert.Contains(t, recorder.Body.String(), swaggerFavicon16Latest)
-	assert.Contains(t, recorder.Body.String(), swaggerFavicon32Latest)
+	t.Run("with defaults ", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+
+		swui.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+
+		assert.Equal(t, "text/html; charset=utf-8", recorder.Header().Get(contentTypeHeader))
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf("<title>%s</title>", o.Title))
+		assert.Contains(t, recorder.Body.String(), fmt.Sprintf(`url: '%s',`, strings.ReplaceAll(o.SpecURL, `/`, `\/`)))
+		assert.Contains(t, recorder.Body.String(), swaggerLatest)
+		assert.Contains(t, recorder.Body.String(), swaggerPresetLatest)
+		assert.Contains(t, recorder.Body.String(), swaggerStylesLatest)
+		assert.Contains(t, recorder.Body.String(), swaggerFavicon16Latest)
+		assert.Contains(t, recorder.Body.String(), swaggerFavicon32Latest)
+	})
+
+	t.Run("with path with a trailing / (issue #238)", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/docs/", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+
+		swui.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+	})
+
+	t.Run("should yield not found", func(t *testing.T) {
+		req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/nowhere", nil)
+		require.NoError(t, err)
+		recorder := httptest.NewRecorder()
+
+		swui.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+
+	t.Run("edge cases", func(t *testing.T) {
+		t.Run("with custom template that fails to execute", func(t *testing.T) {
+			assert.Panics(t, func() {
+				SwaggerUI(SwaggerUIOpts{
+					Template: `<!DOCTYPE html>
+<html>
+	spec-url='{{ .Unknown }}'
+</html>
+`,
+				}, nil)
+			})
+		})
+	})
 }

--- a/middleware/ui_defaults.go
+++ b/middleware/ui_defaults.go
@@ -1,8 +1,0 @@
-package middleware
-
-const (
-	// constants that are common to all UI-serving middlewares
-	defaultDocsPath  = "docs"
-	defaultDocsURL   = "/swagger.json"
-	defaultDocsTitle = "API Documentation"
-)

--- a/middleware/ui_options.go
+++ b/middleware/ui_options.go
@@ -1,0 +1,173 @@
+package middleware
+
+import (
+	"bytes"
+	"encoding/gob"
+	"fmt"
+	"net/http"
+	"path"
+	"strings"
+)
+
+const (
+	// constants that are common to all UI-serving middlewares
+	defaultDocsPath  = "docs"
+	defaultDocsURL   = "/swagger.json"
+	defaultDocsTitle = "API Documentation"
+)
+
+// uiOptions defines common options for UI serving middlewares.
+type uiOptions struct {
+	// BasePath for the UI, defaults to: /
+	BasePath string
+
+	// Path combines with BasePath to construct the path to the UI, defaults to: "docs".
+	Path string
+
+	// SpecURL is the URL of the spec document.
+	//
+	// Defaults to: /swagger.json
+	SpecURL string
+
+	// Title for the documentation site, default to: API documentation
+	Title string
+
+	// Template specifies a custom template to serve the UI
+	Template string
+}
+
+// toCommonUIOptions converts any UI option type to retain the common options.
+//
+// This uses gob encoding/decoding to convert common fields from one struct to another.
+func toCommonUIOptions(opts interface{}) uiOptions {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	dec := gob.NewDecoder(&buf)
+	var o uiOptions
+	err := enc.Encode(opts)
+	if err != nil {
+		panic(err)
+	}
+
+	err = dec.Decode(&o)
+	if err != nil {
+		panic(err)
+	}
+
+	return o
+}
+
+func fromCommonToAnyOptions[T any](source uiOptions, target *T) {
+	var buf bytes.Buffer
+	enc := gob.NewEncoder(&buf)
+	dec := gob.NewDecoder(&buf)
+	err := enc.Encode(source)
+	if err != nil {
+		panic(err)
+	}
+
+	err = dec.Decode(target)
+	if err != nil {
+		panic(err)
+	}
+}
+
+// UIOption can be applied to UI serving middleware, such as Context.APIHandler or
+// Context.APIHandlerSwaggerUI to alter the defaut behavior.
+type UIOption func(*uiOptions)
+
+func uiOptionsWithDefaults(opts []UIOption) uiOptions {
+	var o uiOptions
+	for _, apply := range opts {
+		apply(&o)
+	}
+
+	return o
+}
+
+// WithUIBasePath sets the base path from where to serve the UI assets.
+//
+// By default, Context middleware sets this value to the API base path.
+func WithUIBasePath(base string) UIOption {
+	return func(o *uiOptions) {
+		if !strings.HasPrefix(base, "/") {
+			base = "/" + base
+		}
+		o.BasePath = base
+	}
+}
+
+// WithUIPath sets the path from where to serve the UI assets (i.e. /{basepath}/{path}.
+func WithUIPath(pth string) UIOption {
+	return func(o *uiOptions) {
+		o.Path = pth
+	}
+}
+
+// WithUISpecURL sets the path from where to serve swagger spec document.
+//
+// This may be specified as a full URL or a path.
+//
+// By default, this is "/swagger.json"
+func WithUISpecURL(specURL string) UIOption {
+	return func(o *uiOptions) {
+		o.SpecURL = specURL
+	}
+}
+
+// WithUITitle sets the title of the UI.
+//
+// By default, Context middleware sets this value to the title found in the API spec.
+func WithUITitle(title string) UIOption {
+	return func(o *uiOptions) {
+		o.Title = title
+	}
+}
+
+// WithTemplate allows to set a custom template for the UI.
+//
+// UI middleware will panic if the template does not parse or execute properly.
+func WithTemplate(tpl string) UIOption {
+	return func(o *uiOptions) {
+		o.Template = tpl
+	}
+}
+
+// EnsureDefaults in case some options are missing
+func (r *uiOptions) EnsureDefaults() {
+	if r.BasePath == "" {
+		r.BasePath = "/"
+	}
+	if r.Path == "" {
+		r.Path = defaultDocsPath
+	}
+	if r.SpecURL == "" {
+		r.SpecURL = defaultDocsURL
+	}
+	if r.Title == "" {
+		r.Title = defaultDocsTitle
+	}
+}
+
+// serveUI creates a middleware that serves a templated asset as text/html.
+func serveUI(pth string, assets []byte, next http.Handler) http.Handler {
+	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+		if path.Clean(r.URL.Path) == pth {
+			rw.Header().Set(contentTypeHeader, "text/html; charset=utf-8")
+			rw.WriteHeader(http.StatusOK)
+			_, _ = rw.Write(assets)
+
+			return
+		}
+
+		if next != nil {
+			next.ServeHTTP(rw, r)
+
+			return
+		}
+
+		rw.Header().Set(contentTypeHeader, "text/plain")
+		rw.WriteHeader(http.StatusNotFound)
+		_, _ = rw.Write([]byte(fmt.Sprintf("%q not found", pth)))
+	})
+}

--- a/middleware/ui_options_test.go
+++ b/middleware/ui_options_test.go
@@ -1,0 +1,105 @@
+package middleware
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestConvertOptions(t *testing.T) {
+	t.Run("from any UI options to uiOptions", func(t *testing.T) {
+		t.Run("from RedocOpts", func(t *testing.T) {
+			in := RedocOpts{
+				BasePath: "a",
+				Path:     "b",
+				SpecURL:  "c",
+				Template: "d",
+				Title:    "e",
+				RedocURL: "f",
+			}
+			out := toCommonUIOptions(in)
+
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+
+		t.Run("from RapiDocOpts", func(t *testing.T) {
+			in := RapiDocOpts{
+				BasePath:   "a",
+				Path:       "b",
+				SpecURL:    "c",
+				Template:   "d",
+				Title:      "e",
+				RapiDocURL: "f",
+			}
+			out := toCommonUIOptions(in)
+
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+
+		t.Run("from SwaggerUIOpts", func(t *testing.T) {
+			in := SwaggerUIOpts{
+				BasePath:   "a",
+				Path:       "b",
+				SpecURL:    "c",
+				Template:   "d",
+				Title:      "e",
+				SwaggerURL: "f",
+			}
+			out := toCommonUIOptions(in)
+
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+	})
+
+	t.Run("from uiOptions to any UI options", func(t *testing.T) {
+		in := uiOptions{
+			BasePath: "a",
+			Path:     "b",
+			SpecURL:  "c",
+			Template: "d",
+			Title:    "e",
+		}
+
+		t.Run("to RedocOpts", func(t *testing.T) {
+			var out RedocOpts
+			fromCommonToAnyOptions(in, &out)
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+
+		t.Run("to RapiDocOpts", func(t *testing.T) {
+			var out RapiDocOpts
+			fromCommonToAnyOptions(in, &out)
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+
+		t.Run("to SwaggerUIOpts", func(t *testing.T) {
+			var out SwaggerUIOpts
+			fromCommonToAnyOptions(in, &out)
+			require.Equal(t, "a", out.BasePath)
+			require.Equal(t, "b", out.Path)
+			require.Equal(t, "c", out.SpecURL)
+			require.Equal(t, "d", out.Template)
+			require.Equal(t, "e", out.Title)
+		})
+	})
+}


### PR DESCRIPTION
- refactored UI middleware
  * factorized UI middleware to remove duplicated code
  * factorized UI middleware options: to avoid breaking changes in the options types, there is a decode/encode to a common structure
  * added more options:
    * allows to fully customize the UI template
  * added more unit tests

- Spec middleware: added support for optional SpecOption argument
  * allows to serve the spec from a custom path / document name

- serving with or without trailing "/" (cf. issue #238)
  * replaced path.Join() by path.Clean(), which is the intended behavior (i.e. serve the path, irrespective of the presence of a trailing slash)
  * generalized this behavior to all UI and Spec middleware, not just swaggerUI

- API Context:
  * exposed middleware to serve RapiDoc UI
  * allowed new UIOption (...UIOption) to the APIHandler, etc middleware
  * coordinated UI / Spec middleware to be consistent when non-default path/document URL is served

* fixes #192
* fixes #226