### PR TITLE
test: fixed typos and confusing tests

### DIFF
--- a/bytestream.go
+++ b/bytestream.go
@@ -153,7 +153,7 @@ func ByteStreamProducer(opts ...byteStreamOpt) Producer {
 			return errors.New("ByteStreamProducer requires a writer") // early exit
 		}
 		if data == nil {
-			return errors.New("nil destination for ByteStreamProducer")
+			return errors.New("nil data for ByteStreamProducer")
 		}
 
 		closer := defaultCloser

--- a/csv_test.go
+++ b/csv_test.go
@@ -73,3 +73,16 @@ func TestCSVProducer(t *testing.T) {
 	err = prod.Produce(nil, data)
 	require.Error(t, err)
 }
+
+type readerFromDummy struct {
+	err error
+	b   bytes.Buffer
+}
+
+func (r *readerFromDummy) ReadFrom(rdr io.Reader) (int64, error) {
+	if r.err != nil {
+		return 0, r.err
+	}
+
+	return r.b.ReadFrom(rdr)
+}


### PR DESCRIPTION
This is a follow-up on #273.

I realized that a few typos escaped my review on docstrings and that some misnomers for variables in tests made the tests difficult to read (e.g. rdr for a Writer...).