### PR TITLE
fixed incompatibility with go1.19 introduced with csv producer

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
-        go_version: ['oldstable', 'stable' ]
+        go_version: ['oldstable', 'stable', '1.19' ]
 
     steps:
     - name: Run unit tests

--- a/csv.go
+++ b/csv.go
@@ -124,10 +124,16 @@ func CSVConsumer(opts ...CSVOpt) Consumer {
 				if err := pipeCSV(csvWriter, csvReader, o); err != nil {
 					return err
 				}
-				v.Grow(len(csvWriter.records))
-				v.SetCap(len(csvWriter.records)) // in case Grow was unnessary, trim down the capacity
-				v.SetLen(len(csvWriter.records))
-				reflect.Copy(v, reflect.ValueOf(csvWriter.records))
+
+				/*
+					// with go1.20:
+					v.Grow(len(csvWriter.records))
+					v.SetCap(len(csvWriter.records)) // in case Grow was unnessary, trim down the capacity
+					v.SetLen(len(csvWriter.records))
+					reflect.Copy(v, reflect.ValueOf(csvWriter.records))
+				*/
+				v.SetLen(0)
+				v.Set(reflect.AppendSlice(v, reflect.ValueOf(csvWriter.records)))
 
 				return nil
 


### PR DESCRIPTION
Now the producer uses a go1.19 idiom for reflect.

* fixes #287