### PR TITLE
Svace static analyzer fix

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -307,6 +307,9 @@ type contentTypeValue struct {
 
 // BasePath returns the base path for this API
 func (c *Context) BasePath() string {
+	if c.spec != nil {
+		return ""
+	}
 	return c.spec.BasePath()
 }
 


### PR DESCRIPTION
The Svace static analyzer (https://www.ispras.ru/en/technologies/svace/) flagged this code as suspicious: it could lead to a panic (nil pointer dereference) because spec might be nil.
We have not spec != nil checks in all callers, so this check'd prevent panics