### PR TITLE
fix(vuln): fixed vulnerability in returned error, not escaping single quotes

### DIFF
--- a/client_response.go
+++ b/client_response.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 )
 
 // A ClientResponse represents a client response.
@@ -50,13 +51,17 @@ func NewAPIError(opName string, payload any, code int) *APIError {
 	}
 }
 
+// sanitizer ensures that single quotes are escaped
+var sanitizer = strings.NewReplacer(`\`, `\\`, `'`, `\'`)
+
 func (o *APIError) Error() string {
 	var resp []byte
 	if err, ok := o.Response.(error); ok {
-		resp = []byte("'" + err.Error() + "'")
+		resp = []byte("'" + sanitizer.Replace(err.Error()) + "'")
 	} else {
 		resp, _ = json.Marshal(o.Response)
 	}
+
 	return fmt.Sprintf("%s (status %d): %s", o.OperationName, o.Code, resp)
 }
 


### PR DESCRIPTION
Fixes issue detected by CodeQL vulnerability scan.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
