### PR TITLE
fix: Content-Type of 404 & 405 responses

### DIFF
--- a/middleware/router.go
+++ b/middleware/router.go
@@ -68,13 +68,17 @@ func NewRouter(ctx *Context, next http.Handler) http.Handler {
 			return
 		}
 
+		// Always use the default producer Content-Type for Method not
+		// allowed and Not found responses
+		produces := []string{ctx.api.DefaultProduces()}
+
 		// Not found, check if it exists in the other methods first
 		if others := ctx.AllowedMethods(r); len(others) > 0 {
-			ctx.Respond(rw, r, ctx.analyzer.RequiredProduces(), nil, errors.MethodNotAllowed(r.Method, others))
+			ctx.Respond(rw, r, produces, nil, errors.MethodNotAllowed(r.Method, others))
 			return
 		}
 
-		ctx.Respond(rw, r, ctx.analyzer.RequiredProduces(), nil, errors.NotFound("path %s was not found", r.URL.EscapedPath()))
+		ctx.Respond(rw, r, produces, nil, errors.NotFound("path %s was not found", r.URL.EscapedPath()))
 	})
 }
 

--- a/middleware/router_test.go
+++ b/middleware/router_test.go
@@ -40,6 +40,7 @@ func TestRouterMiddleware(t *testing.T) {
 	require.NoError(t, err)
 
 	mw.ServeHTTP(recorder, request)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	assert.Equal(t, http.StatusMethodNotAllowed, recorder.Code)
 
 	methods := strings.Split(recorder.Header().Get("Allow"), ",")
@@ -51,6 +52,7 @@ func TestRouterMiddleware(t *testing.T) {
 	require.NoError(t, err)
 
 	mw.ServeHTTP(recorder, request)
+	assert.Equal(t, "application/json", recorder.Header().Get("Content-Type"))
 	assert.Equal(t, http.StatusNotFound, recorder.Code)
 
 	recorder = httptest.NewRecorder()


### PR DESCRIPTION
Fixes #372

If a specification contains a default producer Content-Type and at least one route with a specific (and different) producer Content-Type, the Content-Type of 405 and 404 responses was this specific Content-Type.

Now the default producer Content-Type is always used.