### PR TITLE
fixes issue 375: context not preserved after routing

### DIFF
--- a/middleware/router.go
+++ b/middleware/router.go
@@ -65,6 +65,7 @@ func NewRouter(ctx *Context, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
 		if _, rCtx, ok := ctx.RouteInfo(r); ok {
 			next.ServeHTTP(rw, rCtx)
+			*r = *rCtx
 			return
 		}
 

--- a/middleware/router_context_test.go
+++ b/middleware/router_context_test.go
@@ -1,0 +1,65 @@
+package middleware
+
+import (
+	stdcontext "context"
+	stderrors "errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/go-openapi/runtime/internal/testing/petstore"
+	"github.com/go-openapi/testify/v2/assert"
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestRouterContext_Issue375(t *testing.T) {
+	spec, api := petstore.NewAPI(t)
+	spec.Spec().BasePath = "/api/"
+	context := NewContext(spec, api, nil)
+
+	type authCtxKey uint8
+	const authCtx authCtxKey = iota + 1
+	authCtxErr := stderrors.New("test error in context")
+
+	mw := NewRouter(context, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// check context after API middleware
+		authContext := stdcontext.WithValue(r.Context(), authCtx, authCtxErr)
+		*r = *r.WithContext(authContext)
+	}))
+
+	start := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("calling API router with context: %v", authCtxErr)
+		mw.ServeHTTP(w, r)
+
+		value := r.Context().Value(authCtx)
+		assert.NotNilf(t, value, "end of middleware chain: expected to find authCtx in request context")
+
+		if value == nil {
+			w.WriteHeader(http.StatusInternalServerError)
+		}
+
+		errAuth, ok := value.(error)
+		assert.Truef(t, ok, "expected authCtx to be an error, but got: %T", value)
+		t.Logf("got context from request: %v", errAuth)
+		fmt.Fprintf(w, "%v", errAuth)
+		w.WriteHeader(http.StatusOK)
+
+		// *r = *r.WithContext(authContext)
+		// mw.ServeHTTP(w, r)
+	})
+
+	recorder := httptest.NewRecorder()
+	request, err := http.NewRequestWithContext(stdcontext.Background(), http.MethodGet, "/api/pets/123", nil)
+	require.NoError(t, err)
+
+	start.ServeHTTP(recorder, request)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+
+	res := recorder.Result()
+	require.NotNil(t, res.Body)
+	msg, err := io.ReadAll(res.Body)
+	require.NoError(t, err)
+	t.Logf("response message: %q", string(msg))
+}


### PR DESCRIPTION
After RouteInfo is called new request object with new context is passed, and all middlewares handling that request after returning don't have access to it. This fix copies the request with routing context to the request passed as a function variable so all middlewares now preserve the request context.

## Change type

Please select: 🔧 Bug fix

## Short description
<!-- Please provide a short description of your change -->

## Fixes
fixes #375 