### PR TITLE
fix(statuses): align http status text with current standard

### DIFF
--- a/statuses.go
+++ b/statuses.go
@@ -60,7 +60,7 @@ var Statuses = map[int]string{
 	444: "No Response",
 	449: "Retry With",
 	450: "Blocked by Windows Parental Controls",
-	451: "Wrong Exchange Server",
+	451: "Unavailable For Legal Reasons",
 	499: "Client Closed Request",
 	500: "Internal Server Error",
 	501: "Not Implemented",


### PR DESCRIPTION
This concerns dodgy status code 451, now realigned to its current definitions.

* fixes #122

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
