### PR TITLE
fix(client): preserve trailing slash on bare-root path pattern

### DIFF
--- a/client/internal/request/request.go
+++ b/client/internal/request/request.go
@@ -533,14 +533,18 @@ func (r *Request) resolveURLPath(basePath string) (string, url.Values, error) {
 		}
 	}
 
-	reinstateSlash := pathPatternURL.Path != "" && pathPatternURL.Path != "/" &&
-		pathPatternURL.Path[len(pathPatternURL.Path)-1] == '/'
+	// path.Join strips trailing slashes; reinstate one whenever the
+	// pathPattern carried it, including the bare-root case ("/" under a
+	// non-empty basePath, which path.Join would collapse to "/basepath").
+	// The HasSuffix check on urlPath keeps the rewrite idempotent and
+	// avoids producing "//" when basePath is "/" or empty.
+	reinstateSlash := strings.HasSuffix(pathPatternURL.Path, "/")
 
 	urlPath := path.Join(basePathURL.Path, pathPatternURL.Path)
 	for k, v := range r.pathParams {
 		urlPath = strings.ReplaceAll(urlPath, "{"+k+"}", url.PathEscape(v))
 	}
-	if reinstateSlash {
+	if reinstateSlash && !strings.HasSuffix(urlPath, "/") {
 		urlPath += "/"
 	}
 

--- a/client/internal/request/request_test.go
+++ b/client/internal/request/request_test.go
@@ -681,6 +681,42 @@ func TestBuildRequest_BuildHTTP_EscapedPath(t *testing.T) {
 	assert.EqualT(t, req.URL.RawPath, req.URL.EscapedPath())
 }
 
+// TestBuildRequest_BuildHTTP_RootPathTrailingSlash locks in the fix for
+// issue #101: the bare-root pattern "/" under a non-empty basePath must
+// keep its trailing slash, and the bare-root cases that the pre-fix
+// formula avoided ("" / "/" basePath) must still not produce "//".
+func TestBuildRequest_BuildHTTP_RootPathTrailingSlash(t *testing.T) {
+	const bp = "/basepath"
+	cases := []struct {
+		name        string
+		basePath    string
+		pathPattern string
+		wantPath    string
+	}{
+		{"root pattern under non-empty basePath keeps slash (#101)", bp, "/", bp + "/"},
+		{"root pattern under '/' basePath stays '/'", "/", "/", "/"},
+		{"root pattern under empty basePath stays '/'", "", "/", "/"},
+		{"non-root trailing slash still preserved", bp, "/users/", bp + "/users/"},
+		{"no trailing slash on pattern produces no trailing slash", bp, "/users", bp + "/users"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			reqWrtr := runtime.ClientRequestWriterFunc(func(_ runtime.ClientRequest, _ strfmt.Registry) error {
+				return nil
+			})
+			r := New(http.MethodGet, tc.pathPattern, reqWrtr)
+
+			req, cancel, err := r.BuildHTTPContext(t.Context(), runtime.JSONMime, tc.basePath, testProducers, nil, nil)
+			require.NoError(t, err)
+			t.Cleanup(cancel)
+			require.NotNil(t, req)
+
+			assert.EqualT(t, tc.wantPath, req.URL.Path)
+		})
+	}
+}
+
 func TestBuildRequest_BuildHTTP_BasePathWithQueryParameters(t *testing.T) {
 	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
 		_ = req.SetBodyParam(nil)


### PR DESCRIPTION
The reinstateSlash logic in resolveURLPath (introduced in 6cdcb95 to fix #289) deliberately excluded pathPattern == "/" to avoid producing "//" when basePath was empty or "/". That left one combination inconsistent with every other trailing-slash case: basePath=/myservice with pathPattern=/ produced /myservice instead of /myservice/.

Replace the pattern-shape carve-out with a HasSuffix check on the already-built urlPath, which is idempotent and keeps the double-slash cases unchanged.

Closes #101

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
