### PR TITLE
fix(client/tls): correct PEM label and add Ed25519 key support

### DIFF
--- a/client/gencerts_test.go
+++ b/client/gencerts_test.go
@@ -279,7 +279,7 @@ func writePKCS1KeyPair(dir, name string, key *rsa.PrivateKey, certDER []byte) er
 
 	// Write private key
 	keyDER := x509.MarshalPKCS1PrivateKey(key)
-	if err := writePEM(keyPath, "EC PRIVATE KEY", keyDER); err != nil {
+	if err := writePEM(keyPath, "RSA PRIVATE KEY", keyDER); err != nil {
 		return err
 	}
 

--- a/client/runtime_tls_test.go
+++ b/client/runtime_tls_test.go
@@ -5,10 +5,14 @@ package client
 
 import (
 	"crypto"
+	"crypto/ed25519"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/json"
 	"errors"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -59,6 +63,19 @@ func TestRuntimeTLSOptions(t *testing.T) {
 			opts := TLSClientOptions{
 				LoadedKey:         fixtures.ECDSA.LoadedKey,
 				LoadedCertificate: fixtures.ECDSA.LoadedCert,
+			}
+
+			cfg, err := TLSClientAuth(opts)
+			require.NoError(t, err)
+			require.NotNil(t, cfg)
+			assert.Len(t, cfg.Certificates, 1)
+		})
+
+		t.Run("with TLSAuthConfig configured with loaded Ed25519 key/certificate", func(t *testing.T) {
+			edKey, edCert := newEd25519KeyCert(t)
+			opts := TLSClientOptions{
+				LoadedKey:         edKey,
+				LoadedCertificate: edCert,
 			}
 
 			cfg, err := TLSClientAuth(opts)
@@ -258,6 +275,29 @@ type (
 		CertFile string
 	}
 )
+
+func newEd25519KeyCert(t testing.TB) (ed25519.PrivateKey, *x509.Certificate) {
+	t.Helper()
+
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: "ed25519-test"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+
+	der, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+
+	return priv, cert
+}
 
 func systemCAPool(t testing.TB) *x509.CertPool {
 	if goruntime.GOOS == "windows" {

--- a/client/tls.go
+++ b/client/tls.go
@@ -5,12 +5,9 @@ package client
 
 import (
 	"crypto"
-	"crypto/ecdsa"
-	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"errors"
 	"fmt"
 	"net/http"
 	"os"
@@ -47,7 +44,7 @@ type TLSClientOptions struct {
 
 	// LoadedCAPool specifies a pool of RootCAs to use when validating the server's TLS certificate.
 	// If set, it will be combined with the other loaded certificates (see LoadedCA and CA).
-	// If neither LoadedCA or CA is set, the provided pool with override the system
+	// If neither LoadedCA or CA is set, the provided pool will override the system
 	// certificate pool.
 	// The caller must not use the supplied pool after calling TLSClientAuth.
 	LoadedCAPool *x509.CertPool
@@ -114,18 +111,11 @@ func TLSClientAuth(opts TLSClientOptions) (*tls.Config, error) {
 		block := pem.Block{Type: "CERTIFICATE", Bytes: opts.LoadedCertificate.Raw}
 		certPem := pem.EncodeToMemory(&block)
 
-		var keyBytes []byte
-		switch k := opts.LoadedKey.(type) {
-		case *rsa.PrivateKey:
-			keyBytes = x509.MarshalPKCS1PrivateKey(k)
-		case *ecdsa.PrivateKey:
-			var err error
-			keyBytes, err = x509.MarshalECPrivateKey(k)
-			if err != nil {
-				return nil, fmt.Errorf("tls client priv key: %v", err)
-			}
-		default:
-			return nil, errors.New("tls client priv key: unsupported key type")
+		// PKCS#8 covers RSA, ECDSA, Ed25519, X25519 (the key types tls.X509KeyPair
+		// understands) and pairs with the canonical "PRIVATE KEY" PEM label.
+		keyBytes, err := x509.MarshalPKCS8PrivateKey(opts.LoadedKey)
+		if err != nil {
+			return nil, fmt.Errorf("tls client priv key: %v", err)
 		}
 
 		block = pem.Block{Type: "PRIVATE KEY", Bytes: keyBytes}
@@ -166,7 +156,7 @@ func TLSClientAuth(opts TLSClientOptions) (*tls.Config, error) {
 		cfg.RootCAs = opts.LoadedCAPool
 	}
 
-	// apply servername overrride
+	// apply servername override
 	if opts.ServerName != "" {
 		cfg.InsecureSkipVerify = false
 		cfg.ServerName = opts.ServerName


### PR DESCRIPTION
TLSClientAuth marshaled RSA keys as PKCS#1 and ECDSA keys as SEC1, then labeled both PEM blocks as "PRIVATE KEY" — a label conventionally reserved for PKCS#8. The output round-tripped through tls.X509KeyPair only because Go's parser is lenient; stricter consumers would reject it.

Switch to a single x509.MarshalPKCS8PrivateKey call, which matches the "PRIVATE KEY" label naturally and transparently supports Ed25519 (previously rejected by the type switch's default branch).

Also fix gencerts_test.go: writePKCS1KeyPair wrote PKCS#1 RSA bytes under an "EC PRIVATE KEY" label — same class of latent mislabel.

Adds an Ed25519 subtest under TestRuntimeTLSOptions.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
