### PR TITLE
fix: CA cert pool should be cloned not returned as pointer

### DIFF
--- a/client/tls.go
+++ b/client/tls.go
@@ -184,9 +184,10 @@ func TLSClient(opts TLSClientOptions) (*http.Client, error) {
 	return &http.Client{Transport: transport}, nil
 }
 
+// basePool returns pool if non-nil; otherwise it returns a new empty cert pool.
 func basePool(pool *x509.CertPool) *x509.CertPool {
 	if pool == nil {
 		return x509.NewCertPool()
 	}
-	return pool
+	return pool.Clone()
 }


### PR DESCRIPTION
_This PR applies 2/2 suggestions from code quality [AI findings](https://github.com/go-openapi/runtime/security/quality/ai-findings)._

Signed-off-by: Frederic BIDON <fredbi@yahoo.com>