### PR TITLE
test: fix flaky assertion on httptrace

### DIFF
--- a/client/httptrace.go
+++ b/client/httptrace.go
@@ -331,12 +331,13 @@ type instrumentedBody struct {
 func (b *instrumentedBody) Read(p []byte) (int, error) {
 	n, err := b.wrapped.Read(p)
 	if n > 0 {
+		first := b.last.IsZero()
 		var dt time.Duration
-		if !b.last.IsZero() {
+		if !first {
 			dt = time.Since(b.last)
 		}
 		b.last = time.Now()
-		b.sess.onBodyChunk(b.side, n, dt)
+		b.sess.onBodyChunk(b.side, n, dt, first)
 	}
 	return n, err
 }
@@ -368,14 +369,18 @@ func (s *traceSession) wrapResponseBody(body io.ReadCloser) io.ReadCloser {
 }
 
 // onBodyChunk renders a single BodyChunk{Sent,Received} event.
-// dt is the duration since the previous Read on the same body
-// (zero on the first Read).
-func (s *traceSession) onBodyChunk(side bodySide, n int, dt time.Duration) {
-	if dt > 0 {
-		s.emitTf("BodyChunk%s(n=%d, dt=%s)", side, n, round(dt))
+// dt is the duration since the previous Read on the same body and
+// is meaningful only when `first` is false. The first chunk has no
+// preceding read, so the dt= field is suppressed; every subsequent
+// chunk emits dt= unconditionally — even when the measured value
+// rounds to zero (common on Windows, where the system clock
+// resolution is coarser than a fast loopback read loop).
+func (s *traceSession) onBodyChunk(side bodySide, n int, dt time.Duration, first bool) {
+	if first {
+		s.emitTf("BodyChunk%s(n=%d)", side, n)
 		return
 	}
-	s.emitTf("BodyChunk%s(n=%d)", side, n)
+	s.emitTf("BodyChunk%s(n=%d, dt=%s)", side, n, round(dt))
 }
 
 // ---------------------------------------------------------------


### PR DESCRIPTION
## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
