### PR TITLE
docs(security): document constant-time-comparison contract for auth callbacks

### DIFF
--- a/docs/examples/auth/apikey/main.go
+++ b/docs/examples/auth/apikey/main.go
@@ -11,6 +11,7 @@
 package main
 
 import (
+	"crypto/subtle"
 	"log"
 	"net/http"
 	"os"
@@ -40,7 +41,9 @@ func wireAPIKeyAuth() {
 	api.RegisterAuth("key", security.APIKeyAuth(
 		"X-Token", "header",
 		func(token string) (any, error) {
-			if token == "abcdefuvwxyz" {
+			// Use subtle.ConstantTimeCompare to avoid leaking the
+			// expected token byte-by-byte via response timing.
+			if subtle.ConstantTimeCompare([]byte(token), []byte("abcdefuvwxyz")) == 1 {
 				return "alice", nil
 			}
 			return nil, errors.New(http.StatusUnauthorized, "invalid api key")

--- a/docs/examples/auth/basic/main.go
+++ b/docs/examples/auth/basic/main.go
@@ -10,6 +10,7 @@ package main
 
 import (
 	"context"
+	"crypto/subtle"
 	"net/http"
 
 	"github.com/go-openapi/errors"
@@ -33,7 +34,10 @@ type fakePrincipal struct{ Name string }
 type fakeStore struct{}
 
 func (fakeStore) AuthenticateBasic(_ context.Context, user, pass string) (*fakePrincipal, error) {
-	if user == "alice" && pass == "s3cret" {
+	// subtle.ConstantTimeCompare avoids leaking the expected password
+	// byte-by-byte via response timing. The username is non-secret and
+	// compared with `==` purely to short-circuit unknown accounts.
+	if user == "alice" && subtle.ConstantTimeCompare([]byte(pass), []byte("s3cret")) == 1 {
 		return &fakePrincipal{Name: user}, nil
 	}
 	return nil, errors.Unauthenticated("basic")

--- a/security/authenticator.go
+++ b/security/authenticator.go
@@ -42,22 +42,42 @@ func ScopedAuthenticator(handler func(*ScopedAuthRequest) (bool, any, error)) ru
 	})
 }
 
-// UserPassAuthentication authentication function.
+// UserPassAuthentication validates a basic-auth credential.
+//
+// Implementations comparing the password (or any derived secret) against a
+// known value MUST use [crypto/subtle.ConstantTimeCompare]: the runtime
+// extracts the credential from the request and delegates the comparison
+// here, and does not enforce a constant-time posture on the caller's behalf.
 type UserPassAuthentication func(string, string) (any, error)
 
-// UserPassAuthenticationCtx authentication function with [context.Context].
+// UserPassAuthenticationCtx is the [context.Context]-aware variant of
+// [UserPassAuthentication]. The same constant-time-comparison guidance
+// applies.
 type UserPassAuthenticationCtx func(context.Context, string, string) (context.Context, any, error)
 
-// TokenAuthentication authentication function.
+// TokenAuthentication validates an API-key token.
+//
+// Implementations comparing the token against a known value MUST use
+// [crypto/subtle.ConstantTimeCompare]; the runtime delegates the comparison
+// here and does not enforce a constant-time posture on the caller's behalf.
 type TokenAuthentication func(string) (any, error)
 
-// TokenAuthenticationCtx authentication function with [context.Context].
+// TokenAuthenticationCtx is the [context.Context]-aware variant of
+// [TokenAuthentication]. The same constant-time-comparison guidance
+// applies.
 type TokenAuthenticationCtx func(context.Context, string) (context.Context, any, error)
 
-// ScopedTokenAuthentication authentication function.
+// ScopedTokenAuthentication validates a bearer/OAuth2 token along with the
+// scopes required for the operation.
+//
+// Implementations comparing the token against a known value MUST use
+// [crypto/subtle.ConstantTimeCompare]; the runtime delegates the comparison
+// here and does not enforce a constant-time posture on the caller's behalf.
 type ScopedTokenAuthentication func(string, []string) (any, error)
 
-// ScopedTokenAuthenticationCtx authentication function with [context.Context].
+// ScopedTokenAuthenticationCtx is the [context.Context]-aware variant of
+// [ScopedTokenAuthentication]. The same constant-time-comparison guidance
+// applies.
 type ScopedTokenAuthenticationCtx func(context.Context, string, []string) (context.Context, any, error)
 
 var DefaultRealmName = "API"


### PR DESCRIPTION
The runtime delegates credential comparison to caller-supplied authentication callbacks (UserPassAuthentication, TokenAuthentication, ScopedTokenAuthentication, and their Ctx variants). Callers that compare a secret against a known value must use
crypto/subtle.ConstantTimeCompare to avoid response-timing side-channels.

This commit:
- Documents the contract on all six callback type godocs.
- Updates the apikey and basic auth examples to demonstrate the safe pattern, so users copying the snippets inherit it.

No API change. The runtime itself does not compare secrets and remains structurally timing-safe.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
