### PR TITLE
refactor(client): promote ContextualTransport to runtime package

### DIFF
--- a/client/opentelemetry.go
+++ b/client/opentelemetry.go
@@ -29,12 +29,12 @@ const (
 // A new client span is created for each request.
 // The provided opts are applied to each spans - for example to add global tags.
 //
-// The returned transport satisfies [ContextualTransport]: callers
+// The returned transport satisfies [runtime.ContextualTransport]: callers
 // should prefer [openTelemetryTransport.SubmitContext] over the
 // legacy [runtime.ClientOperation.Context] field. Setting that
 // field is still honored on the [openTelemetryTransport.Submit]
 // compatibility path.
-func (r *Runtime) WithOpenTelemetry(opts ...OpenTelemetryOpt) ContextualTransport {
+func (r *Runtime) WithOpenTelemetry(opts ...OpenTelemetryOpt) runtime.ContextualTransport {
 	return newOpenTelemetryTransport(r, r.Host, opts)
 }
 
@@ -58,7 +58,7 @@ func (r *Runtime) WithOpenTelemetry(opts ...OpenTelemetryOpt) ContextualTranspor
 // usual opentracing options and opentracing-enabled transport.
 //
 // Passed options are ignored unless they are of type [OpenTelemetryOpt].
-func (r *Runtime) WithOpenTracing(opts ...any) ContextualTransport {
+func (r *Runtime) WithOpenTracing(opts ...any) runtime.ContextualTransport {
 	otelOpts := make([]OpenTelemetryOpt, 0, len(opts))
 	for _, o := range opts {
 		otelOpt, ok := o.(OpenTelemetryOpt)
@@ -179,7 +179,7 @@ func (t *openTelemetryTransport) Submit(op *runtime.ClientOperation) (any, error
 // transport's SubmitContext call. The legacy
 // [runtime.ClientOperation.Context] field is not consulted.
 //
-// When the wrapped transport implements [ContextualTransport], ctx is
+// When the wrapped transport implements [runtime.ContextualTransport], ctx is
 // forwarded directly via its SubmitContext. Otherwise, the legacy
 // Submit path is used: ctx is stamped onto op.Context for the
 // duration of that call and restored afterwards, so the wrapped
@@ -228,7 +228,7 @@ func (t *openTelemetryTransport) SubmitContext(ctx context.Context, op *runtime.
 
 //nolint:contextcheck // ctx is forwarded verbatim; the legacy Submit branch only stamps it onto op.Context for the wrapped transport.
 func (t *openTelemetryTransport) submitWrapped(ctx context.Context, op *runtime.ClientOperation) (any, error) {
-	if sc, ok := t.transport.(ContextualTransport); ok {
+	if sc, ok := t.transport.(runtime.ContextualTransport); ok {
 		return sc.SubmitContext(ctx, op)
 	}
 	prev := op.Context

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -44,7 +44,8 @@ type Runtime struct {
 	Host     string
 	BasePath string
 	Formats  strfmt.Registry
-	Context  context.Context //nolint:containedctx  // we precisely want this type to contain the request context
+	// Deprecated: prefer [runtime.ContextualTransport.SubmitContext] to pass the request context explicitly.
+	Context context.Context //nolint:containedctx  // we precisely want this type to contain the request context
 
 	Debug bool
 
@@ -84,6 +85,8 @@ type Runtime struct {
 	schemes    []string
 	response   ClientResponseFunc
 }
+
+var _ runtime.ContextualTransport = &Runtime{}
 
 // New creates a new default runtime for a swagger api runtime.Client.
 func New(host, basePath string, schemes []string) *Runtime {
@@ -186,22 +189,6 @@ func (r *Runtime) CreateHTTPRequestContext(ctx context.Context, operation *runti
 func (r *Runtime) CreateHttpRequest(operation *runtime.ClientOperation) (req *http.Request, err error) { //nolint:revive
 	req, _, err = r.createHTTPRequestContext(context.Background(), operation)
 	return
-}
-
-// ContextualTransport extends [runtime.ClientTransport] with an
-// explicit context-aware submission method.
-//
-// [Runtime] satisfies it via [Runtime.SubmitContext]. Wrappers such
-// as the OpenTelemetry transport type-assert to this interface so
-// they can forward an explicit context to the underlying transport
-// without setting the cached [runtime.ClientOperation.Context] field.
-//
-// In v2, SubmitContext will be folded into [runtime.ClientTransport]
-// itself and the cached context field removed; this interface is the
-// v0.x bridge.
-type ContextualTransport interface {
-	runtime.ClientTransport
-	SubmitContext(context.Context, *runtime.ClientOperation) (any, error)
 }
 
 // Submit a request and when there is a body on success it will turn that into the result
@@ -309,7 +296,7 @@ func (r *Runtime) SetResponseReader(f ClientResponseFunc) {
 
 func (r *Runtime) ensureContext(operation *runtime.ClientOperation) context.Context {
 	switch {
-	case operation.Context != nil:
+	case operation.Context != nil: //nolint:staticcheck // kept for backward compatibility
 		return operation.Context
 	case r.Context != nil:
 		return r.Context

--- a/client_operation.go
+++ b/client_operation.go
@@ -19,12 +19,30 @@ type ClientOperation struct {
 	AuthInfo           ClientAuthInfoWriter
 	Params             ClientRequestWriter
 	Reader             ClientResponseReader
-	Context            context.Context //nolint:containedctx // we precisely want this type to contain the request context
-	Client             *http.Client
+	// Deprecated: prefer [ContextualTransport.SubmitContext] to pass the request context explicitly.
+	Context context.Context //nolint:containedctx // we precisely want this type to contain the request context
+	Client  *http.Client
 }
 
 // A ClientTransport implementor knows how to submit Request objects to some destination.
 type ClientTransport interface {
-	// Submit(string, RequestWriter, ResponseReader, AuthInfoWriter) (interface{}, error)
+	// Submit the operation and return the deserialized response or an error.
 	Submit(*ClientOperation) (any, error)
+}
+
+// ContextualTransport extends [ClientTransport] with an explicit
+// context-aware submission method.
+//
+// Wrappers such as the OpenTelemetry transport type-assert to this
+// interface so they can forward an explicit context to the underlying
+// transport without setting the cached [ClientOperation.Context] field.
+//
+// In v2, SubmitContext will be folded into [ClientTransport] itself
+// and the cached [ClientOperation.Context] field removed; this interface
+// is the v0.x bridge.
+type ContextualTransport interface {
+	ClientTransport
+
+	// SubmitContext submits the operation using ctx as the request context.
+	SubmitContext(ctx context.Context, operation *ClientOperation) (any, error)
 }


### PR DESCRIPTION
Move ContextualTransport from client/ to the runtime root package so it sits side-by-side with ClientTransport, its canonical home. Update WithOpenTelemetry/WithOpenTracing return types and the submitWrapped type assertion to use the qualified name.

Mark the cached Context fields on runtime.ClientOperation and client.Runtime as Deprecated, redirecting callers to ContextualTransport.SubmitContext. The internal ensureContext fallback keeps reading the legacy field under an explicit //nolint:staticcheck.

Refresh stale commented signatures on ClientTransport.Submit and ContextualTransport.SubmitContext with short modern docstrings.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
