### PR TITLE
fix(client): added a guard to avoid the client to panic

### DIFF
--- a/client/internal/request/request.go
+++ b/client/internal/request/request.go
@@ -818,7 +818,11 @@ func (r *Request) writeStreamPayload(mediaType string, producers map[string]runt
 // The same reasoning applies to the form/multipart branch.
 func (r *Request) writeNonStreamPayload(mediaType string, producers map[string]runtime.Producer) (io.Reader, error) {
 	r.header.Set(runtime.HeaderContentType, mediaType)
-	producer := producers[mediaType]
+	producer, ok := producers[mediaType]
+	if !ok {
+		return nil, fmt.Errorf("no producer registered for content type %q (register one with Runtime.Producers)", mediaType)
+	}
+
 	if err := producer.Produce(r.buf, r.payload); err != nil {
 		return nil, err
 	}

--- a/client/internal/request/request_test.go
+++ b/client/internal/request/request_test.go
@@ -236,6 +236,28 @@ func TestBuildRequest_BuildHTTP_Payload(t *testing.T) {
 	assert.Equal(t, append(expectedBody, '\n'), actualBody)
 }
 
+// TestBuildRequest_BuildHTTP_UnregisteredProducer guards against a
+// regression of go-swagger/go-swagger#3192: a non-stream payload sent
+// with a media type that has no producer registered must surface an
+// actionable error rather than panic on a nil-method dispatch.
+func TestBuildRequest_BuildHTTP_UnregisteredProducer(t *testing.T) {
+	bd := []struct{ Name, Hobby string }{{valTom, valOregonTrail}}
+	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {
+		_ = req.SetBodyParam(bd)
+		return nil
+	})
+	r := New(http.MethodPost, "/flats/", reqWrtr)
+
+	const unregisteredMime = "application/x-not-registered"
+	req, cancel, err := r.BuildHTTPContext(t.Context(), unregisteredMime, "", testProducers, nil, nil)
+	t.Cleanup(cancel)
+
+	require.Error(t, err)
+	assert.Nil(t, req)
+	assert.Contains(t, err.Error(), unregisteredMime)
+	assert.Contains(t, err.Error(), "no producer registered")
+}
+
 func TestBuildRequest_BuildHTTP_SetsInAuth(t *testing.T) {
 	bd := []struct{ Name, Hobby string }{{valTom, valOregonTrail}, {valJohn, valBirdWatching}}
 	reqWrtr := runtime.ClientRequestWriterFunc(func(req runtime.ClientRequest, _ strfmt.Registry) error {

--- a/client/runtime.go
+++ b/client/runtime.go
@@ -95,13 +95,15 @@ func New(host, basePath string, schemes []string) *Runtime {
 
 	// Enhancement proposal: https://github.com/go-openapi/runtime/issues/385
 	rt.Consumers = map[string]runtime.Consumer{
-		runtime.YAMLMime:    yamlpc.YAMLConsumer(),
-		runtime.JSONMime:    runtime.JSONConsumer(),
-		runtime.XMLMime:     runtime.XMLConsumer(),
-		runtime.TextMime:    runtime.TextConsumer(),
-		runtime.HTMLMime:    runtime.TextConsumer(),
-		runtime.CSVMime:     runtime.CSVConsumer(),
-		runtime.DefaultMime: runtime.ByteStreamConsumer(),
+		runtime.YAMLMime:           yamlpc.YAMLConsumer(),
+		runtime.JSONMime:           runtime.JSONConsumer(),
+		runtime.XMLMime:            runtime.XMLConsumer(),
+		runtime.TextMime:           runtime.TextConsumer(),
+		runtime.HTMLMime:           runtime.TextConsumer(),
+		runtime.CSVMime:            runtime.CSVConsumer(),
+		runtime.MultipartFormMime:  runtime.ByteStreamConsumer(),
+		runtime.URLencodedFormMime: runtime.ByteStreamConsumer(),
+		runtime.DefaultMime:        runtime.ByteStreamConsumer(),
 	}
 	rt.Producers = map[string]runtime.Producer{
 		runtime.YAMLMime:    yamlpc.YAMLProducer(),


### PR DESCRIPTION
The client used to panic when hitting an unregistered producer.

This now returns an error as we expect clients to explicitly register their content producers.

* contributes go-swagger/go-swagger#3192

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [x] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [x] I have rebased and squashed my work, so only one commit remains
* [x] I have added tests to cover my changes.
* [x] I have properly enriched go doc comments in code.
* [x] I have properly documented any breaking change.
