### PR TITLE
middleware: set http.Request.Pattern to the matched route

### DIFF
--- a/middleware/context.go
+++ b/middleware/context.go
@@ -442,6 +442,7 @@ func (c *Context) RouteInfo(request *http.Request) (*MatchedRoute, *http.Request
 
 	if route, ok := c.LookupRoute(request); ok {
 		rCtx = stdContext.WithValue(rCtx, ctxMatchedRoute, route)
+		request.Pattern = route.BasePath + route.PathPattern
 		return route, request.WithContext(rCtx), ok
 	}
 

--- a/middleware/context_pattern_test.go
+++ b/middleware/context_pattern_test.go
@@ -1,0 +1,43 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/go-openapi/runtime"
+	"github.com/go-openapi/runtime/internal/testing/petstore"
+	"github.com/go-openapi/testify/v2/assert"
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestRouteInfoSetsRequestPattern(t *testing.T) {
+	spec, api := petstore.NewAPI(t)
+	ctx := NewContext(spec, api, nil)
+	ctx.router = DefaultRouter(spec, ctx.api)
+
+	t.Run("sets Request.Pattern to the matched route", func(t *testing.T) {
+		request, err := runtime.JSONRequest(http.MethodGet, "/api/pets/123", nil)
+		require.NoError(t, err)
+
+		mr, reqWithCtx, ok := ctx.RouteInfo(request)
+		require.True(t, ok)
+		require.NotNil(t, reqWithCtx)
+
+		assert.Equal(t, mr.BasePath+mr.PathPattern, reqWithCtx.Pattern)
+		assert.True(t, strings.HasSuffix(reqWithCtx.Pattern, "/pets/{id}"), reqWithCtx.Pattern)
+		assert.Equal(t, reqWithCtx.Pattern, request.Pattern)
+	})
+
+	t.Run("leaves Request.Pattern empty when no route matches", func(t *testing.T) {
+		request, err := runtime.JSONRequest(http.MethodGet, "/api/not-a-route", nil)
+		require.NoError(t, err)
+
+		_, _, ok := ctx.RouteInfo(request)
+		require.False(t, ok)
+		assert.Empty(t, request.Pattern)
+	})
+}


### PR DESCRIPTION
## Motivation

Since Go 1.22, `http.Request.Pattern` carries the route pattern that matched a request. Router-agnostic observability middleware — OpenTelemetry's `otelhttp`, Prometheus, structured logging — reads it to label spans/metrics by **route template** (bounded cardinality) rather than raw path. `net/http.ServeMux` populates it; third-party routers increasingly do the same.

go-openapi already matches the route (`middleware.MatchedRouteFrom`), but consumers must hand-write a bespoke middleware to copy the matched pattern into their tracing/metrics labels — see e.g. go-swagger/go-swagger#3124, where users assemble an `otelhttp` wrapper by hand. Populating `Request.Pattern` lets standard middleware pick up the route with zero go-openapi-specific code (e.g. `otelhttp.NewHandler` then names spans by the matched route).

## Change

In `Context.RouteInfo`, when a route matches, set `request.Pattern` to `BasePath + PathPattern` (e.g. `/api/pets/{id}`). It is set **in place** — mirroring `net/http.ServeMux` — so a handler wrapping the router observes it (a `WithContext` copy would only be visible downstream). It stays empty for unmatched requests, exactly like `ServeMux`. No behavior change for code that does not read `Request.Pattern`.

`Request.Pattern` requires Go 1.22+; this module is already on `go 1.25`.

## Test

Added `TestRouteInfoSetsRequestPattern` (petstore fixture): asserts `Request.Pattern` equals the matched `BasePath+PathPattern` on both the returned and the in-place request, and stays empty when no route matches.
